### PR TITLE
ELEX-1304-interval fix redo

### DIFF
--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -153,8 +153,8 @@ class CombinedDataHandler(object):
 
     def get_unexpected_units(self, percent_reporting_threshold, aggregates):
         """
-        Gets reporting but unexpected data. These are units that are fully reporting, but
-        we have no preprocessed data for them.
+        Gets reporting but unexpected data. These are units that are may or may not be fully 
+        reporting, but we have no preprocessed data for them.
         """
         expected_geographic_units = self._get_expected_geographic_unit_fips().tolist()
         # Note: this uses current_data because self.data drops unexpected units

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -153,7 +153,7 @@ class CombinedDataHandler(object):
 
     def get_unexpected_units(self, percent_reporting_threshold, aggregates):
         """
-        Gets reporting but unexpected data. These are units that are may or may not be fully 
+        Gets reporting but unexpected data. These are units that are may or may not be fully
         reporting, but we have no preprocessed data for them.
         """
         expected_geographic_units = self._get_expected_geographic_unit_fips().tolist()

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -117,9 +117,9 @@ class BaseElectionModel(object):
         Aggregate nonreporting votes by aggregate (ie. postal_code, county_fips etc.). Note that all unexpected
         units - whether or not they are fully reporting - are handled in "_get_reporting_aggregate_votes" above
         """
-        aggregate_nonreporting_units_known_votes = nonreporting_units.groupby(aggregate).sum().reset_index(drop=False)        
+        aggregate_nonreporting_units_known_votes = nonreporting_units.groupby(aggregate).sum().reset_index(drop=False)
 
-        return  aggregate_nonreporting_units_known_votes
+        return aggregate_nonreporting_units_known_votes
 
     def get_aggregate_predictions(self, reporting_units, nonreporting_units, unexpected_units, aggregate, estimand):
         """

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -71,7 +71,8 @@ class BaseElectionModel(object):
     def _get_reporting_aggregate_votes(self, reporting_units, unexpected_units, aggregate, estimand):
         """
         Aggregate reporting votes by aggregate (ie. postal_code, county_fips etc.). This function
-        adds reporting data and reporting unexpected data by aggregate.
+        adds reporting data and reporting unexpected data by aggregate. Note that all unexpected units -
+        whether or not they are fully reporting - are included in this function.
         """
         reporting_units_known_votes = reporting_units.groupby(aggregate).sum().reset_index(drop=False)
 
@@ -110,6 +111,15 @@ class BaseElectionModel(object):
             )
 
         return aggregate_votes
+
+    def _get_nonreporting_aggregate_votes(self, nonreporting_units, aggregate):
+        """
+        Aggregate nonreporting votes by aggregate (ie. postal_code, county_fips etc.). Note that all unexpected
+        units - whether or not they are fully reporting - are handled in "_get_reporting_aggregate_votes" above
+        """
+        aggregate_nonreporting_units_known_votes = nonreporting_units.groupby(aggregate).sum().reset_index(drop=False)        
+
+        return  aggregate_nonreporting_units_known_votes
 
     def get_aggregate_predictions(self, reporting_units, nonreporting_units, unexpected_units, aggregate, estimand):
         """

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -99,9 +99,9 @@ class GaussianElectionModel(BaseElectionModel):
         # get reporting votes by aggregate
         aggregate_votes = self._get_reporting_aggregate_votes(reporting_units, unexpected_units, aggregate, estimand)
 
-        #get non reporting votes by aggregate (votes cast in units that haven't met reporting threshold
-        #yet, but still have returns)
-        aggregate_nonreporting_votes = self._get_nonreporting_aggregate_votes(nonreporting_units,aggregate)
+        # get non reporting votes by aggregate (votes cast in units that haven't met reporting threshold
+        # yet, but still have returns)
+        aggregate_nonreporting_votes = self._get_nonreporting_aggregate_votes(nonreporting_units, aggregate)
 
         # get last election results by aggregate (for un-residualizing later)
         last_election = (
@@ -227,8 +227,12 @@ class GaussianElectionModel(BaseElectionModel):
         aggregate_prediction_intervals = (
             last_election.merge(modeled_bounds, how="inner", on=aggregate)
             .assign(
-                predicted_lower=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.lb, aggregate_nonreporting_votes[f"results_{estimand}"]),
-                predicted_upper=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.ub, aggregate_nonreporting_votes[f"results_{estimand}"]),
+                predicted_lower=lambda x: np.maximum(
+                    x[f"last_election_results_{estimand}"] + x.lb, aggregate_nonreporting_votes[f"results_{estimand}"]
+                ),
+                predicted_upper=lambda x: np.maximum(
+                    x[f"last_election_results_{estimand}"] + x.ub, aggregate_nonreporting_votes[f"results_{estimand}"]
+                ),
             )
             .drop(columns=f"last_election_results_{estimand}")
         )

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -99,6 +99,10 @@ class GaussianElectionModel(BaseElectionModel):
         # get reporting votes by aggregate
         aggregate_votes = self._get_reporting_aggregate_votes(reporting_units, unexpected_units, aggregate, estimand)
 
+        #get non reporting votes by aggregate (votes cast in units that haven't met reporting threshold
+        #yet, but still have returns)
+        aggregate_nonreporting_votes = self._get_nonreporting_aggregate_votes(nonreporting_units,aggregate)
+
         # get last election results by aggregate (for un-residualizing later)
         last_election = (
             nonreporting_units.groupby(aggregate)
@@ -216,12 +220,15 @@ class GaussianElectionModel(BaseElectionModel):
         ]
 
         # un-residualize bounds by adding last election results
-        # elementwise maximum with zero to avoid adding negative vote count in nonreporting units
+        # elementwise maximum with zero to avoid adding negative vote count in nonreporting units# elementwise maximum with votes from nonreporting units to avoid adding negative vote count in nonreporting units
+        # Note, gaussian interval aggregation can result in  a lower bound that is less than the votes
+        # already returned in non-reporting units. If that is the case we correct by assigning the number of votes
+        # already returned in nonreporting units.
         aggregate_prediction_intervals = (
             last_election.merge(modeled_bounds, how="inner", on=aggregate)
             .assign(
-                predicted_lower=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.lb, 0),
-                predicted_upper=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.ub, 0),
+                predicted_lower=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.lb, aggregate_nonreporting_votes[f"results_{estimand}"]),
+                predicted_upper=lambda x: np.maximum(x[f"last_election_results_{estimand}"] + x.ub, aggregate_nonreporting_votes[f"results_{estimand}"]),
             )
             .drop(columns=f"last_election_results_{estimand}")
         )

--- a/tests/models/test_base_election_model.py
+++ b/tests/models/test_base_election_model.py
@@ -188,10 +188,11 @@ def test_aggregation_simple():
         }
     ).equals(df3)
 
+
 def test_aggregation_nonreporting_simple():
     """
     This test is a basic test for aggregating votes from nonreporting units.These are votes
-    that have been counted from units that haven't met our reporting threshold. 
+    that have been counted from units that haven't met our reporting threshold.
     """
     model_settings = {}
     model = BaseElectionModel.BaseElectionModel(model_settings)
@@ -208,6 +209,7 @@ def test_aggregation_nonreporting_simple():
     df2 = model._get_nonreporting_aggregate_votes(df1, aggregate=["c1"])
 
     assert pd.DataFrame({"c1": ["a", "b", "c"], f"results_{estimand}": [4, 16, 6], "reporting": [0, 0, 0]}).equals(df2)
+
 
 def test_aggregation(va_governor_precinct_data):
     """
@@ -241,6 +243,7 @@ def test_aggregation(va_governor_precinct_data):
         == df3[f"results_{estimand}"].values[0]
     )
 
+
 def test_aggregation_nonreporting(va_governor_precinct_data):
     """
     Testing nonreporting aggregation using the 2017 Virginia governor precinct results as test data.
@@ -264,8 +267,8 @@ def test_aggregation_nonreporting(va_governor_precinct_data):
 
     df3 = model._get_nonreporting_aggregate_votes(df1, aggregate=["county_fips"])
     assert 10664.0 == df3[f"results_{estimand}"].values[0]  # first county based on summing csv
-    
-    
+
+
 def test_get_aggregate_predictions_simple():
     """
     This is a basic test for our prediction aggregation. We sum the results of the reporting and reporting


### PR DESCRIPTION
## Description
Interval fix correcting the problem of the lower bound of confidence intervals having fewer votes than a candidate's current returns. This issue was only in the gaussian model due to aggregation.
## Jira Ticket
Elex-1304 https://arcpublishing.atlassian.net/jira/software/c/projects/ELEX/boards/1026?modal=detail&selectedIssue=ELEX-1304
## Test Steps
Run new unit tests. Run model on 2020 historical presidential elections.
