### PR TITLE
elex-1283-fix-set-index-warning

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -435,7 +435,7 @@ class HistoricalModelClient(ModelClient):
         aggregates = [a for a in aggregates if a != "unit"]
         for estimand in estimands:
             results_unit = preprocessed_data[
-                set(aggregates + ["postal_code", "geographic_unit_fips", f"results_{estimand}"])
+                list(set(aggregates + ["postal_code", "geographic_unit_fips", f"results_{estimand}"]))
             ].rename(columns={f"results_{estimand}": f"raw_results_{estimand}"})
             evaluation = {}
             evaluation["unit_data"] = self.compute_evaluation(


### PR DESCRIPTION
## Description
Indexing a dataframe with a set is going to be deprecated in the future. Wrapping the set in a list to avoid the warning.

## Jira Ticket
[elex-1283](https://arcpublishing.atlassian.net/browse/ELEX-1283)

## Test Steps
In develop this would throw the warning:
```
elexmodel 2021-11-02_VA_G --estimands=dem --office_id=G --geographic_unit_type=precinct --percent_reporting 60 --historical
```
in this branch the warning is gone.