### PR TITLE
1302 save results even with not enough subunits

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -211,7 +211,9 @@ class ModelClient(object):
             minimum_reporting_units = model.get_minimum_reporting_units(alpha)
             if minimum_reporting_units > minimum_reporting_units_max:
                 minimum_reporting_units_max = minimum_reporting_units
-        # minimum_reporting_units_max += 1
+
+        if APP_ENV != "local" and save_results:
+            data.write_data(election_id, office)
 
         n_reporting_expected_units = reporting_units.shape[0]
         n_unexpected_units = unexpected_units.shape[0]
@@ -236,9 +238,6 @@ class ModelClient(object):
         results_handler = ModelResultsHandler(
             aggregates, prediction_intervals, reporting_units, nonreporting_units, unexpected_units
         )
-
-        if APP_ENV != "local" and save_results:
-            data.write_data(election_id, office)
 
         for estimand in estimands:
             unit_predictions = model.get_unit_predictions(reporting_units, nonreporting_units, estimand)


### PR DESCRIPTION
## Description
We want to write the results to s3 even if the model run doesn't happen because we don't have enough subunits. This helps with pure results analysis on election night and debugging.

## Jira Ticket
[elex-1302](https://arcpublishing.atlassian.net/browse/ELEX-1302)

## Test Steps
Change `APP_ENV` to `dev` locally. Then this line:
```
elexmodel 2017-11-07_VA_G --estimands=dem --office_id=G --geographic_unit_type=county --pi_method=gaussian --percent_reporting 1 --save_output=results
```
should not do anything in `develop` branch, but should update the results file in `dev` bucket in this branch.