### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,38 @@
-name: Release Stable Version
+name: Publish stable version
 on:
   push:
     branches:
       - main
 jobs:
-  test-publish:
-    - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
-        repository_url: https://test.pypi.org/legacy/
-  publish:
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
+  build-and-publish:
+    name: Build Python distribution and publish to TestPyPi and PyPi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v1
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+      - name: Publish package to TestPyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
       - name: Install pypa/build
         run: >-
           python -m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,16 @@ on:
     branches:
       - main
 jobs:
-  - name: Publish package to TestPyPI
-    uses: pypa/gh-action-pypi-publish@release/v1
-    with:
-      user: ${{ secrets.PYPI_USERNAME }}
-      password: ${{ secrets.PYPI_PASSWORD }}
-      repository_url: https://test.pypi.org/legacy/
-  - name: Publish package to PyPI
-    uses: pypa/gh-action-pypi-publish@release/v1
-    with:
-      user: ${{ secrets.PYPI_USERNAME }}
-      password: ${{ secrets.PYPI_PASSWORD }}
+  test-publish:
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}
+        repository_url: https://test.pypi.org/legacy/
+  publish:
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pre-commit run --all-files
 
 ### Release
 
-To release a new version:
+To release a new version manually: 
 - Decide what the next version will be per semantic versioning: `X.X.X`
 - Make a new branch from develop called `release/X.X.X`
 - Update the version in `setup.py`
@@ -152,11 +152,17 @@ To release a new version:
 - Once the PR is merged, tag main (or develop for a beta release) with the version's release number (`git tag X.X.X`) and push that tag to github (`git push --tags`)
 - Merge main into develop
 
-After this is done, we need to get the new release into jfrog:
-- Make sure `requirements-dev.txt` is installed
-- Run `python setup.py install bdist_wheel`
-- Check to make sure the correct version is installed in the `dist/` folder that should now exist at the base of the repo folder. If you've previously run these commands locally for an earlier version, you may need to delete the older files in `dist/` order to upload them correctly in the next step. You can just delete the entire `dist/` folder and run the above command again.
-- Run `twine upload dist/* --repository-url REPOSITORY_URL -u USERNAME -p PASSWORD`
+Then, we need to release this version to PyPi.This repository has a Github Action workflow that automatically builds and releases the latest version to TestPyPi and PyPi on pushes to `main`. However, to release to PyPi manually:
+- Generate a distribution archive:
+  - Make sure `requirements-dev.txt` is installed
+  - Run `python3 -m pip install --upgrade build` to install `build`
+  - Run `python3 -m build`. This should generate two files in the `dist/` directory.
+  - Check to make sure the correct version is installed in the `dist/` folder that should now exist at the base of the repo folder. If you've previously run these commands locally for an earlier version, you may need to delete the older files in `dist/` order to upload them correctly in the next step. You can just delete the entire `dist/` folder and run the above command again.
+- Upload the distribution archive:`
+  - Run `python3 -m pip install --upgrade twine`
+  - Upload to TestPyPi with `python3 -m twine upload --repository testpypi dist/*`
+  - Upload to PyPi `python3 -m twine upload dist/*`
+
 
 ## Further Reading
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",
     ],
-    description="A package for optimization solvers",
+    description="A package for the Washington Post's live election night model",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     license="MIT",


### PR DESCRIPTION
## Description

Lenny noticed a failed workflow run with a syntax error: https://github.com/washingtonpost/elex-live-model/actions/runs/3184227746/workflow 

This PR:
- Updates the workflow to build the package
- Updates release instructions in the README
- Updates the package description

## Test Steps

I used [`act` ](https://github.com/nektos/act)to test this workflow locally and deployed v1.0.5 successfully to TestPyPi.