### PR TITLE
elex-1507 fix mape when uncontested historical baseline

### DIFF
--- a/src/elexmodel/utils/math_utils.py
+++ b/src/elexmodel/utils/math_utils.py
@@ -1,7 +1,7 @@
 import logging
+import math
 
 import numpy as np
-import math
 from scipy.stats import bootstrap
 
 LOG = logging.getLogger()

--- a/src/elexmodel/utils/math_utils.py
+++ b/src/elexmodel/utils/math_utils.py
@@ -74,7 +74,11 @@ def compute_error(true, pred, type_="mae"):
         return np.mean(np.abs(true - pred)).round(decimals=0)
     elif type_ == "mape":
         mask = true != 0
-        return np.mean((np.abs(true - pred) / true)[mask]).round(decimals=2)
+        mape_vector = (np.abs(true - pred) / true)[mask]
+        # if all true values are zero, then race was uncontested and mape doesn't make sense to compute
+        if mape_vector.shape[0] == 0:
+            return np.nan
+        return np.mean(mape_vector).round(decimals=2)
 
 
 def compute_frac_within_pi(lower, upper, results):

--- a/src/elexmodel/utils/math_utils.py
+++ b/src/elexmodel/utils/math_utils.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import math
 from scipy.stats import bootstrap
 
 LOG = logging.getLogger()
@@ -74,11 +75,11 @@ def compute_error(true, pred, type_="mae"):
         return np.mean(np.abs(true - pred)).round(decimals=0)
     elif type_ == "mape":
         mask = true != 0
-        mape_vector = (np.abs(true - pred) / true)[mask]
+        mape = np.mean((np.abs(true - pred) / true)[mask])
         # if all true values are zero, then race was uncontested and mape doesn't make sense to compute
-        if mape_vector.shape[0] == 0:
-            return np.nan
-        return np.mean(mape_vector).round(decimals=2)
+        if math.isnan(mape):
+            return mape
+        return mape.round(decimals=2)
 
 
 def compute_frac_within_pi(lower, upper, results):

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -1,6 +1,7 @@
+import math
+
 import numpy as np
 import pandas as pd
-import math
 import pytest
 
 from elexmodel.utils import math_utils
@@ -102,6 +103,7 @@ def test_compute_mae():
     y_pred = y_true + 180
     assert math_utils.compute_error(y_true, y_pred, type_="mae") == pytest.approx(180)
 
+
 @pytest.mark.filterwarnings("ignore:divide by zero")
 def test_compute_mape():
     random_number_generator = np.random.RandomState(42)
@@ -116,9 +118,10 @@ def test_compute_mape():
     assert math_utils.compute_error(y_true, y_pred, type_="mape") == pytest.approx(mape)
 
     # if all true values are zero
-    y_true = pd.Series(np.asarray([0, 0, 0, 0, 0, 0])) # cast as series to generate same error exactly
-    y_pred =pd.Series(np.asarray([10, 4, 8, 20, 5, 8]))
+    y_true = pd.Series(np.asarray([0, 0, 0, 0, 0, 0]))  # cast as series to generate same error exactly
+    y_pred = pd.Series(np.asarray([10, 4, 8, 20, 5, 8]))
     assert math.isnan(math_utils.compute_error(y_true, y_pred, type_="mape"))
+
 
 def test_compute_frac_within_pi():
     lower = np.asarray([0, 1, 4, 10, 5, 3])

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pandas as pd
+import math
 import pytest
 
 from elexmodel.utils import math_utils
@@ -100,13 +102,23 @@ def test_compute_mae():
     y_pred = y_true + 180
     assert math_utils.compute_error(y_true, y_pred, type_="mae") == pytest.approx(180)
 
-
+@pytest.mark.filterwarnings("ignore:divide by zero")
 def test_compute_mape():
     random_number_generator = np.random.RandomState(42)
     y_true = random_number_generator.exponential(size=100)
     y_pred = 1.8 * y_true
     assert math_utils.compute_error(y_true, y_pred, type_="mape") == pytest.approx(0.8)
 
+    # if multiple true values are zero
+    y_true = pd.Series(np.asarray([0, 1, 4, 0, 5, 3]))
+    y_pred = pd.Series(np.asarray([10, 4, 8, 20, 5, 8]))
+    mape = round((abs(1 - 4) / 1 + abs(4 - 8) / 4 + abs(5 - 5) / 5 + abs(3 - 8) / 3) / 4, 2)
+    assert math_utils.compute_error(y_true, y_pred, type_="mape") == pytest.approx(mape)
+
+    # if all true values are zero
+    y_true = pd.Series(np.asarray([0, 0, 0, 0, 0, 0])) # cast as series to generate same error exactly
+    y_pred =pd.Series(np.asarray([10, 4, 8, 20, 5, 8]))
+    assert math.isnan(math_utils.compute_error(y_true, y_pred, type_="mape"))
 
 def test_compute_frac_within_pi():
     lower = np.asarray([0, 1, 4, 10, 5, 3])


### PR DESCRIPTION
## Description
In the case where a race was uncontested in a historical baseline (ie. 2016 senate election when running 2022 senate with `--historical` flag) all `true` values are zero. When computing the `mape` this meant that the mape vector was empty after removing all zero values with the mask. Taking the mean of an empty pandas series generated a `nan` which we then tried to round, causing an error.

Instead we now check whether the mape is `nan` and if it is we turn directly, otherwise we round.

Also added a unit test in the cases where some true values are zero and in this case, where all true values are zero. If some true values are zero there is a divide by zero warning, which I ignore in the test since it's expected.

## Jira Ticket
[elex-1507](https://arcpublishing.atlassian.net/browse/ELEX-1507)

## Test Steps
This call should no longer break (which it does in develop). 
```
elexmodel 2022-11-08_USA_G --office_id=S --aggregates=postal_code --pi_method=nonparametric --geographic_unit_type=county --percent_reporting_threshold=99 --prediction_intervals=0.9 --historical --percent_reporting=20 --estimands=gop
```
Also `tox`