### PR TITLE
Elex 1509 ecos solver fix when relative weights small

### DIFF
--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -1,7 +1,8 @@
 import math
-from collections import namedtuple
 import warnings
-warnings.filterwarnings('error', category=UserWarning, module='cvxpy')
+from collections import namedtuple
+
+warnings.filterwarnings("error", category=UserWarning, module="cvxpy")
 import logging
 
 import cvxpy
@@ -11,6 +12,8 @@ from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
 PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper", "conformalization"], defaults=(None,) * 3)
 
 LOG = logging.getLogger(__name__)
+
+
 class BaseElectionModel(object):
     def __init__(self, model_settings={}):
         self.qr = QuantileRegressionSolver(solver="ECOS")
@@ -42,14 +45,11 @@ class BaseElectionModel(object):
         # of the smallest weight is too close to zero, it can lead to numerical instability
         # where the solver either throws a warning for inaccurate solution or breaks entirely
         # in that case, we catch the error and warning and re-run with normalize_weights false
-        #import pdb; pdb.set_trace()
-        model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=normalize_weights)
-
-        #try:
-        #    model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=normalize_weights)
-        #except (UserWarning, cvxpy.error.SolverError) as e:
-        #    LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False")
-        #    model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=False)
+        try:
+            model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=normalize_weights)
+        except (UserWarning, cvxpy.error.SolverError) as e:
+            LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False")
+            model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=False)
 
         # generate new coefficient matrix with zeroes for all coefficents
         coefficients = np.zeros((df_X.shape[1],))

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -1,13 +1,13 @@
+import logging
 import math
 import warnings
 from collections import namedtuple
 
-warnings.filterwarnings("error", category=UserWarning, module="cvxpy")
-import logging
-
 import cvxpy
 import numpy as np
 from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
+
+warnings.filterwarnings("error", category=UserWarning, module="cvxpy")
 
 PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper", "conformalization"], defaults=(None,) * 3)
 
@@ -47,8 +47,8 @@ class BaseElectionModel(object):
         # in that case, we catch the error and warning and re-run with normalize_weights false
         try:
             model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=normalize_weights)
-        except (UserWarning, cvxpy.error.SolverError) as e:
-            LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False")
+        except (UserWarning, cvxpy.error.SolverError):
+            LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
             model.fit(X, y, tau_value=tau, weights=weights, normalize_weights=False)
 
         # generate new coefficient matrix with zeroes for all coefficents


### PR DESCRIPTION
## Description
Usually we normalize the weights before passing them into the quantile regression solver because that speeds the solution up. However, it seems that if the normalized smallest weight is too close to zero, then that throws a warning about inaccurate solutions or occasionally throws an error. 

Now, if a warning or an error is thrown we catch it and re-run the quantile regression solver with `normalize_weights=False`, this is slower but should be more accurate.

## Jira Ticket
[elex-1509](https://arcpublishing.atlassian.net/browse/ELEX-1509)

## Test Steps
This would throw an uncaught warning or sometimes error out. Now no longer does that:
```
elexmodel 2022-11-08_USA_G --office_id=S --aggregates=postal_code --pi_method=nonparametric --geographic_unit_type=county --percent_reporting_threshold=99 --prediction_intervals=0.9 --historical --percent_reporting=20 --estimands=dem
```