### PR TITLE
Config changes to account for new office format

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -50,6 +50,8 @@ class ModelClient(object):
         robust,
         handle_unreporting,
     ):
+        # Account for config change
+        office = f"{office}_{geographic_unit_type}"
         offices = config_handler.get_offices()
         if office not in offices:
             raise ValueError(f"Office '{office}' is not valid. Please check config.")
@@ -150,8 +152,8 @@ class ModelClient(object):
             robust,
             handle_unreporting,
         )
-        states_with_election = config_handler.get_states(office)
-        estimand_baselines = config_handler.get_estimand_baselines(office, estimands)
+        states_with_election = config_handler.get_states(f"{office}_{geographic_unit_type}")
+        estimand_baselines = config_handler.get_estimand_baselines(f"{office}_{geographic_unit_type}", estimands)
 
         LOG.info("Getting preprocessed data: %s", election_id)
         preprocessed_data_handler = PreprocessedDataHandler(

--- a/src/elexmodel/handlers/data/PreprocessedData.py
+++ b/src/elexmodel/handlers/data/PreprocessedData.py
@@ -64,7 +64,7 @@ class PreprocessedDataHandler(object):
 
     def get_preprocessed_data_path(self):
         directory_path = get_directory_path()
-        path = f"{directory_path}/data/{self.election_id}/{self.office}/data_{self.geographic_unit_type}.csv"
+        path = f"{directory_path}/data/{self.election_id}/{self.office}_{self.geographic_unit_type}/data_{self.geographic_unit_type}.csv"
         return path
 
     def select_rows_in_states(self, data, states_with_election):

--- a/src/elexmodel/handlers/s3.py
+++ b/src/elexmodel/handlers/s3.py
@@ -36,7 +36,7 @@ class S3Util(object):
 
     def get_file_path(self, file_type, path_info):
         if file_type == "preprocessed":
-            file_path = f'{S3_FILE_PATH}/{path_info["election_id"]}/data/{path_info["office"]}/data_{path_info["geographic_unit_type"]}.csv'
+            file_path = f'{S3_FILE_PATH}/{path_info["election_id"]}/data/{path_info["office"]}_{path_info["geographic_unit_type"]}/data_{path_info["geographic_unit_type"]}.csv'
         elif file_type == "config":
             file_path = f'{S3_FILE_PATH}/{path_info["election_id"]}/config/{path_info["election_id"]}'
         return file_path

--- a/tests/fixtures/config/2017-11-07_VA_G.json
+++ b/tests/fixtures/config/2017-11-07_VA_G.json
@@ -1,8 +1,8 @@
 {
     "2017-11-07_VA_G": [{
-        "office": "Y",
+        "office": "Y_precinct-district",
         "states": ["VA"],
-        "geographic_unit_types": ["precinct-district", "county-district"],
+        "geographic_unit_types": ["precinct-district"],
         "baseline_results_year": 2015,
         "historical_election": [],
         "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 
@@ -15,9 +15,24 @@
         "fixed_effect": ["postal_code",  "county_fips", "county_classification", "district"],
         "__comment": "Fips codes are of the format {district_num}_51{county_fips}_{precinct_id} to account for any split precincts"
     }, {
-        "office": "G",
+        "office": "G_precinct",
         "states": ["VA"],
-        "geographic_unit_types": ["precinct", "county"],
+        "geographic_unit_types": ["precinct"],
+        "baseline_results_year": 2013,
+        "historical_election": [],
+        "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 
+            "age_geq_65", "ethnicity_east_and_south_asian",
+            "ethnicity_european", "ethnicity_hispanic_and_portuguese",
+            "ethnicity_likely_african_american", "ethnicity_other",
+            "gender_f", "gender_m", 
+            "median_household_income", "percent_bachelor_or_higher"],
+        "aggregates": ["postal_code", "county_classification", "county_fips", "unit"],
+        "fixed_effect": ["postal_code",  "county_fips", "county_classification"]
+    },
+    {
+        "office": "G_county",
+        "states": ["VA"],
+        "geographic_unit_types": ["county"],
         "baseline_results_year": 2013,
         "historical_election": [],
         "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 

--- a/tests/fixtures/config/2018-03-06_TX_R.json
+++ b/tests/fixtures/config/2018-03-06_TX_R.json
@@ -1,6 +1,6 @@
 {
     "2018-03-06_TX_R": [{
-        "office": "G",
+        "office": "G_county",
         "states": ["TX"],
         "geographic_unit_types": ["county"],
         "baseline_results_year": 2014,

--- a/tests/fixtures/config/2019-11-05_VA_G.json
+++ b/tests/fixtures/config/2019-11-05_VA_G.json
@@ -1,8 +1,8 @@
 {
     "2019-11-05_VA_G": [{
-        "office": "Y",
+        "office": "Y_precinct-district",
         "states": ["VA"],
-        "geographic_unit_types": ["precinct-district", "county-district"],
+        "geographic_unit_types": ["precinct-district"],
         "baseline_results_year": 2017,
         "historical_election": ["2017-11-07_VA_G"],
         "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 

--- a/tests/fixtures/config/2020-08-04_AZ_R.json
+++ b/tests/fixtures/config/2020-08-04_AZ_R.json
@@ -1,6 +1,6 @@
 {
     "2020-08-04_AZ_R": [{
-        "office": "S",
+        "office": "S_precinct",
         "states": ["AZ"],
         "geographic_unit_types": ["precinct"],
         "baseline_results_year": 2018,

--- a/tests/fixtures/config/2021-11-02_VA_G.json
+++ b/tests/fixtures/config/2021-11-02_VA_G.json
@@ -1,8 +1,8 @@
 {
     "2021-11-02_VA_G": [{
-        "office": "G",
+        "office": "G_precinct",
         "states": ["VA"],
-        "geographic_unit_types": ["county", "precinct"],
+        "geographic_unit_types": ["precinct"],
         "baseline_results_year": 2017,
         "historical_election": ["2017-11-07_VA_G"],
         "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 
@@ -14,9 +14,9 @@
         "aggregates": ["unit", "postal_code", "county_classification", "county_fips"],
         "fixed_effect": ["postal_code",  "county_fips", "county_classification"]
     }, {
-        "office": "Y",
+        "office": "Y_precinct-district",
         "states": ["VA"],
-        "geographic_unit_types": ["county-district", "precinct-district"],
+        "geographic_unit_types": ["precinct-district"],
         "baseline_results_year": 2019,
         "historical_election": ["2017-11-07_VA_G", "2019-11-05_VA_G"],
         "features": ["age_le_30", "age_geq_30_le_45", "age_geq_45_le_65", 

--- a/tests/handlers/test_s3.py
+++ b/tests/handlers/test_s3.py
@@ -22,7 +22,7 @@ def test_s3_put(test_s3_util):
 def test_s3_get_file_path_preprocessed(test_s3_util):
     file_type = "preprocessed"
     path_info = {"election_id": "2017-11-07_VA_G", "office": "G", "geographic_unit_type": "county"}
-    assert test_s3_util.get_file_path(file_type, path_info) == f"{S3_FILE_PATH}/2017-11-07_VA_G/data/G/data_county.csv"
+    assert test_s3_util.get_file_path(file_type, path_info) == f"{S3_FILE_PATH}/2017-11-07_VA_G/data/G_county/data_county.csv"
 
 
 def test_s3_get_file_path_config(test_s3_util):


### PR DESCRIPTION
## Description

We need to separate offices by geographic unit type so we can match them to different historical elections. This is a temporary config change for the election on Tuesday and we plan on doing a larger restructuring of the config after this deadline

## Test Steps

In the data importer, run `pip install <path to local elex-live-model repo>` and run the model commands listed here: https://www.notion.so/news-engineering/Nov-2022-Model-commands-1b15fad4524d45499ba9102cb689687a
