### PR TITLE
Fix/save non reporting bounds

### DIFF
--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -61,8 +61,6 @@ class GaussianElectionModel(BaseElectionModel):
         # save for later, but need to copy to avoid changing the original
         self.alpha_to_nonreporting_lower_bounds[alpha] = prediction_intervals.lower.copy()
         self.alpha_to_nonreporting_upper_bounds[alpha] = prediction_intervals.upper.copy()
-        #self.nonreporting_lower_bounds = prediction_intervals.lower.copy()
-        #self.nonreporting_upper_bounds = prediction_intervals.upper.copy()
 
         # apply correction
         lower = prediction_intervals.lower - lower_correction

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -11,6 +11,8 @@ class GaussianElectionModel(BaseElectionModel):
         super().__init__(model_settings)
         self.model_settings = model_settings
         self.beta = model_settings.get("beta", 1)
+        self.alpha_to_nonreporting_lower_bounds = {}
+        self.alpha_to_nonreporting_upper_bounds = {}
 
     def _compute_conf_frac(self):
         """
@@ -57,8 +59,10 @@ class GaussianElectionModel(BaseElectionModel):
         )
 
         # save for later, but need to copy to avoid changing the original
-        self.nonreporting_lower_bounds = prediction_intervals.lower.copy()
-        self.nonreporting_upper_bounds = prediction_intervals.upper.copy()
+        self.alpha_to_nonreporting_lower_bounds[alpha] = prediction_intervals.lower.copy()
+        self.alpha_to_nonreporting_upper_bounds[alpha] = prediction_intervals.upper.copy()
+        #self.nonreporting_lower_bounds = prediction_intervals.lower.copy()
+        #self.nonreporting_upper_bounds = prediction_intervals.upper.copy()
 
         # apply correction
         lower = prediction_intervals.lower - lower_correction
@@ -130,8 +134,8 @@ class GaussianElectionModel(BaseElectionModel):
 
         # assign nonreporting unadjusted lower/upper bounds to unobsered data
         bounds = nonreporting_units.assign(
-            nonreporting_lower_bounds=self.nonreporting_lower_bounds,
-            nonreporting_upper_bounds=self.nonreporting_upper_bounds,
+            nonreporting_lower_bounds=self.alpha_to_nonreporting_lower_bounds[alpha],
+            nonreporting_upper_bounds=self.alpha_to_nonreporting_upper_bounds[alpha],
         )
 
         # un-normalize unadjusted lower/upper bounds and sum per group to get unadjusted group bounds


### PR DESCRIPTION
## Description
This is a fix for an issue where the aggregated prediction intervals for the gaussian model were smaller when alpha was larger (ie. 90% prediction intervals were smaller than 80% prediction intervals than 70% prediction intervals etc.). See screenshot:
![Screen Shot 2022-11-18 at 5 19 41 PM](https://user-images.githubusercontent.com/6954332/202908314-75688b7d-4ea2-4fff-8d22-64d45405c2d3.png)

This should not be the case, since 90% prediction intervals should contain the true value 90% of the time and 80% prediction intervals should contain the true value 80% of the time. So the 90% prediction intervals should be larger than 80% prediction intervals (since they need to cover more to achieve the higher coverage).

The issue was caused by us overwriting the saved value of nonreporting upper and lower bounds when producing the unit prediction intervals. So the non reporting upper/lower bounds that were used when constructing the aggregate prediction intervals were always those for the last alpha value (usually the largest). We now save the nonreporting upper/lower bounds based on the alpha, to avoid this issue. 

This is what the same run looks like now:
![Screen Shot 2022-11-20 at 3 35 52 PM](https://user-images.githubusercontent.com/6954332/202908329-9b3e27bf-acc9-43d2-bfe3-90b5a24a55ca.png)



## Jira Ticket

## Test Steps
Run this in develop and in the current branch to see the difference:
```
elexmodel 2017-11-07_VA_G --estimands=dem --office_id=G --geographic_unit_type=precinct --percent_reporting 10 --pi_method=gaussian --prediction_intervals=0.6 --prediction_intervals=0.7 --prediction_intervals=0.8 --prediction_intervals=0.9 --features=percent_bachelor_or_higher
```