### PR TITLE
Fix/elex 1981 fixed effect bug

### DIFF
--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -42,29 +42,20 @@ class CombinedDataHandler(object):
             data.loc[indices_with_null_val, "percent_expected_vote"] = 0
         self.fixed_effects = fixed_effects
         self.expanded_fixed_effects = []
-        if len(self.fixed_effects) > 0:
-            data = self._expand_fixed_effects(data, self.fixed_effects)
-            self.expanded_fixed_effects = [
-                x
-                for x in data.columns
-                if x.startswith(tuple([fixed_effect + "_" for fixed_effect in self.fixed_effects]))
-            ]
 
         self.data = data
 
     @classmethod
-    def _expand_fixed_effects(self, data, fixed_effects):
+    def _expand_fixed_effects(self, data, fixed_effects, drop_first):
         """
         Turn fixed effect columns into dummy variables. Concatenates original columns also
         """
-        # for each fixed efffect we want to return the column as a categorical (dummy) variable
-        # drop_first is True to avoid linear dependence of dummy variables
         # we concatenate the dummies with the original fixed effects, since we need the original fixed effect
         # columns in order to potentially aggregate on them.
         original_fixed_effect_columns = data[fixed_effects]
         return pd.concat(
             [
-                pd.get_dummies(data, columns=fixed_effects, prefix=fixed_effects, dtype=np.int64, drop_first=True),
+                pd.get_dummies(data, columns=fixed_effects, prefix=fixed_effects, prefix_sep='_', dtype=np.int64, drop_first=drop_first),
                 original_fixed_effect_columns,
             ],
             axis=1,
@@ -97,6 +88,19 @@ class CombinedDataHandler(object):
             # we effectively always need the intercept for the model to work
             reporting_units["intercept"] = 1
 
+        if len(self.fixed_effects) > 0:
+            # drop_first is True for reporting units since we want to avoid the design matrix with 
+            # expanded fixed effects to be linearly dependent
+            reporting_units = self._expand_fixed_effects(reporting_units, self.fixed_effects, drop_first=True)
+            # we save the expanded fixed effects to be able to add fixed effects that are not in the non-reporting
+            # units as a zero column and to be able to specify the order of the expanded fixed effect when fitting
+            # the model
+            self.expanded_fixed_effects = [
+                x
+                for x in reporting_units.columns
+                if x.startswith(tuple([fixed_effect + "_" for fixed_effect in self.fixed_effects]))
+            ]
+
         reporting_units["reporting"] = 1
         return reporting_units
 
@@ -119,6 +123,15 @@ class CombinedDataHandler(object):
 
         if add_intercept:
             nonreporting_units["intercept"] = 1
+
+        if len(self.fixed_effects) > 0:
+            nonreporting_units = self._expand_fixed_effects(nonreporting_units, self.fixed_effects, drop_first=False)
+            # if all units from one fixed effect are reporting they will not appear in the nonreporting_units and won't 
+            # get a column when we expand the fixed effects on that dataframe. Therefore we add those columns with zero
+            # fixed effects manually.
+            for expanded_fixed_effect in self.expanded_fixed_effects:
+                if expanded_fixed_effect not in nonreporting_units.columns:
+                    nonreporting_units[expanded_fixed_effect] = 0
 
         nonreporting_units["reporting"] = 0
 

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -55,7 +55,14 @@ class CombinedDataHandler(object):
         original_fixed_effect_columns = data[fixed_effects]
         return pd.concat(
             [
-                pd.get_dummies(data, columns=fixed_effects, prefix=fixed_effects, prefix_sep='_', dtype=np.int64, drop_first=drop_first),
+                pd.get_dummies(
+                    data,
+                    columns=fixed_effects,
+                    prefix=fixed_effects,
+                    prefix_sep="_",
+                    dtype=np.int64,
+                    drop_first=drop_first,
+                ),
                 original_fixed_effect_columns,
             ],
             axis=1,
@@ -89,7 +96,7 @@ class CombinedDataHandler(object):
             reporting_units["intercept"] = 1
 
         if len(self.fixed_effects) > 0:
-            # drop_first is True for reporting units since we want to avoid the design matrix with 
+            # drop_first is True for reporting units since we want to avoid the design matrix with
             # expanded fixed effects to be linearly dependent
             reporting_units = self._expand_fixed_effects(reporting_units, self.fixed_effects, drop_first=True)
             # we save the expanded fixed effects to be able to add fixed effects that are not in the non-reporting
@@ -127,7 +134,7 @@ class CombinedDataHandler(object):
         if len(self.fixed_effects) > 0:
             missing_expanded_fixed_effects = {}
             nonreporting_units = self._expand_fixed_effects(nonreporting_units, self.fixed_effects, drop_first=False)
-            # if all units from one fixed effect are reporting they will not appear in the nonreporting_units and won't 
+            # if all units from one fixed effect are reporting they will not appear in the nonreporting_units and won't
             # get a column when we expand the fixed effects on that dataframe. Therefore we add those columns with zero
             # fixed effects manually.
             for expanded_fixed_effect in self.expanded_fixed_effects:

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -26,7 +26,7 @@ class BaseElectionModel(object):
         """
         Fits the quantile regression for the model
         Removes two kinds of columns and then substitutes zeroes as those coefficients:
-            Zero columns: these are caused by  fixed effects that don't appear in df_X.
+            Zero columns: these are caused by fixed effects that don't appear in df_X.
                 The dummy variables were created using all data (not just the reporting data).
                 So the corresponding columns for fixed ffects that only appear in non-reporting units
                 will be all zero in the reporting matrix.
@@ -62,6 +62,8 @@ class BaseElectionModel(object):
         Produces unit level predictions. Fits quantile regression to reporting data, applies
         it to nonreporting data. The features are specified in model_settings.
         """
+        # specifying self.features extracts the correct columns and makes sure they are in the correct
+        # order. Necessary when fitting and predicting on the model.
         reporting_units_features = reporting_units[self.features]
         nonreporting_units_features = nonreporting_units[self.features]
 
@@ -201,6 +203,8 @@ class BaseElectionModel(object):
         train_rows = math.floor(reporting_units.shape[0] * conf_frac)
         train_data = reporting_units_shuffled[:train_rows].reset_index(drop=True)
 
+        # specifying self.features extracts the correct columns and makes sure they are in the correct
+        # order. Necessary when fitting and predicting on the model.
         train_data_features = train_data[self.features]
         train_data_residuals = train_data[f"residuals_{estimand}"]
         train_data_weights = train_data[f"total_voters_{estimand}"]

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -147,14 +147,14 @@ def test_generate_fixed_effects(va_governor_county_data):
         fixed_effects=["county_classification"],
         handle_unreporting="drop",
     )
-    
+
     reporting_data = combined_data_handler.get_reporting_units(99)
     nonreporting_data = combined_data_handler.get_nonreporting_units(99)
 
     assert combined_data_handler.data.shape == (133, 33)
 
-    n_expected_columns = combined_data_handler.data.shape[1] + 3 # residual intercept and reporting
-    n_expected_columns += 5 # 6 - 1 the fixed effects with one dropped
+    n_expected_columns = combined_data_handler.data.shape[1] + 3  # residual intercept and reporting
+    n_expected_columns += 5  # 6 - 1 the fixed effects with one dropped
     assert reporting_data.shape == (133, n_expected_columns)
     assert nonreporting_data.shape == (0, n_expected_columns)
 
@@ -178,10 +178,10 @@ def test_generate_fixed_effects(va_governor_county_data):
 
     assert combined_data_handler.data.shape == (133, 33)
 
-    n_expected_columns = combined_data_handler.data.shape[1] + 3 # residual intercept and reporting
-    n_expected_columns += 6 + 133 - 2 # subtracting two dropped columns
-    assert reporting_data.shape == (133, n_expected_columns) 
-    assert nonreporting_data.shape == (0, n_expected_columns) 
+    n_expected_columns = combined_data_handler.data.shape[1] + 3  # residual intercept and reporting
+    n_expected_columns += 6 + 133 - 2  # subtracting two dropped columns
+    assert reporting_data.shape == (133, n_expected_columns)
+    assert nonreporting_data.shape == (0, n_expected_columns)
 
     assert "county_classification_nova" in reporting_data.columns
     assert "county_classification_nova" in nonreporting_data.columns
@@ -193,7 +193,8 @@ def test_generate_fixed_effects(va_governor_county_data):
     assert "county_fips" in combined_data_handler.fixed_effects
     assert len(combined_data_handler.expanded_fixed_effects) == 137  # 6 + 133 - 2
 
-def test_test_generate_fixed_effects_complex(va_governor_county_data):
+
+def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     """
     This tests adding fixed effects when not all units are reporting and therefore
     only a subset of the fixed effect categories are added as columns to the reporting data
@@ -221,33 +222,34 @@ def test_test_generate_fixed_effects_complex(va_governor_county_data):
         fixed_effects=["county_fips"],
         handle_unreporting="drop",
     )
-    
+
     reporting_data = combined_data_handler.get_reporting_units(99)
     nonreporting_data = combined_data_handler.get_nonreporting_units(99)
 
     assert combined_data_handler.data.shape == (133, 33)
 
-    n_expected_columns = combined_data_handler.data.shape[1] + 3 # residual intercept and reporting
-    n_expected_columns += n - 1 # for dropped 
+    n_expected_columns = combined_data_handler.data.shape[1] + 3  # residual intercept and reporting
+    n_expected_columns += n - 1  # for dropped
     assert reporting_data.shape == (n, n_expected_columns)
     assert nonreporting_data.shape == (133 - n, n_expected_columns + (133 - n))
 
-    assert "county_fips_51001" not in reporting_data.columns # dropped fromg get_dummies because first
-    assert "county_fips_51001" not in nonreporting_data.columns # not added manually nor in nonreporting data
+    assert "county_fips_51001" not in reporting_data.columns  # dropped fromg get_dummies because first
+    assert "county_fips_51001" not in nonreporting_data.columns  # not added manually nor in nonreporting data
 
-    assert "county_fips_51003" in reporting_data.columns # in here because get_dummies
-    assert "county_fips_51003" in nonreporting_data.columns # in here because manaully added
+    assert "county_fips_51003" in reporting_data.columns  # in here because get_dummies
+    assert "county_fips_51003" in nonreporting_data.columns  # in here because manaully added
 
-    assert "county_fips_51790" not in reporting_data.columns # not in here because not reporting
-    assert "county_fips_51790" in nonreporting_data.columns # in here because get_dummies
+    assert "county_fips_51790" not in reporting_data.columns  # not in here because not reporting
+    assert "county_fips_51790" in nonreporting_data.columns  # in here because get_dummies
 
     assert "county_fips" in combined_data_handler.fixed_effects
     assert len(combined_data_handler.expanded_fixed_effects) == n - 1
 
-def test_test_generate_fixed_effects_complex(va_governor_precinct_data):
+
+def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
     """
-    This tests adding fixed effects when not all units are reporting and therefore
-    only a subset of the fixed effect categories are added as columns to the reporting data
+    This tests adding fixed effects when not all units are reporting but units from the fixed
+    effects appear in both the reporting and the nonreporting set.
     """
     election_id = "2017-11-07_VA_G"
     office = "G"
@@ -272,27 +274,27 @@ def test_test_generate_fixed_effects_complex(va_governor_precinct_data):
         fixed_effects=["county_fips"],
         handle_unreporting="drop",
     )
-    
+
     reporting_data = combined_data_handler.get_reporting_units(99)
     nonreporting_data = combined_data_handler.get_nonreporting_units(99)
     assert combined_data_handler.data.shape == (2360, 33)
 
-    n_expected_columns = combined_data_handler.data.shape[1] + 3 # residual intercept and reporting
-    n_expected_columns += 7 - 1 # when n = 100 we get to county 51013
+    n_expected_columns = combined_data_handler.data.shape[1] + 3  # residual intercept and reporting
+    n_expected_columns += 7 - 1  # when n = 100 we get to county 51013
     assert reporting_data.shape == (n, n_expected_columns)
     assert nonreporting_data.shape == (2360 - n, n_expected_columns + (133 - 7))
 
-    assert "county_fips_51001" not in reporting_data.columns # dropped fromg get_dummies because first
-    assert "county_fips_51001" not in nonreporting_data.columns # not added manually nor in nonreporting data
+    assert "county_fips_51001" not in reporting_data.columns  # dropped fromg get_dummies because first
+    assert "county_fips_51001" not in nonreporting_data.columns  # not added manually nor in nonreporting data
 
-    assert "county_fips_51003" in reporting_data.columns # in here because get_dummies
-    assert "county_fips_51003" in nonreporting_data.columns # in here because manaully added
+    assert "county_fips_51003" in reporting_data.columns  # in here because get_dummies
+    assert "county_fips_51003" in nonreporting_data.columns  # in here because manaully added
 
-    assert "county_fips_51013" in reporting_data.columns # in here because get_dummies
-    assert "county_fips_51013" in nonreporting_data.columns # in here because get_dummies and drop_first=False
+    assert "county_fips_51013" in reporting_data.columns  # in here because get_dummies
+    assert "county_fips_51013" in nonreporting_data.columns  # in here because get_dummies and drop_first=False
 
-    assert "county_fips_51790" not in reporting_data.columns # not in here because not reporting
-    assert "county_fips_51790" in nonreporting_data.columns # in here because get_dummies
+    assert "county_fips_51790" not in reporting_data.columns  # not in here because not reporting
+    assert "county_fips_51790" in nonreporting_data.columns  # in here because get_dummies
 
     assert "county_fips" in combined_data_handler.fixed_effects
     assert len(combined_data_handler.expanded_fixed_effects) == 7 - 1

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -205,6 +205,22 @@ def test_expanding_fixed_effects_basic():
         ),
     )
 
+    df = pd.DataFrame({"c1": ["a", "b", "b", "c"], "c2": ["w", "x", "y", "z"], "c3": [2, 4, 1, 9]})
+    expanded = CombinedDataHandler._expand_fixed_effects(df, ["c1"], drop_first=False)
+    pd.testing.assert_frame_equal(
+        expanded,
+        pd.DataFrame(
+            {
+                "c2": ["w", "x", "y", "z"],
+                "c3": [2, 4, 1, 9],
+                "c1_a": [1, 0, 0, 0],
+                "c1_b": [0, 1, 1, 0],
+                "c1_c": [0, 0, 0, 1],
+                "c1": ["a", "b", "b", "c"],
+            }
+        ),
+    )
+
     expanded = CombinedDataHandler._expand_fixed_effects(df, ["c1", "c2"], drop_first=True)
     pd.testing.assert_frame_equal(
         expanded,


### PR DESCRIPTION
## Description
Fixed effect bug where the fixed effect category of the unit that came first in the preprocessed data needed to have at least one reporting unit so that covariate matrix was invertible. 

On election night in November we couldn't add a fixed effect before Alabama had at least one reporting county. This was because we used `pd.get_dummies(..., drop_first=True)`, where `drop_first=True` was supposed to make sure that the matrix was invertible. However, it drops the first column independently of whether that fixed effect has a reporting unit or not. So before Alabama was reporting, and while using `postal_code` fixed effects we ran into the issue where the column we were dropping was all zeroes. Which did nothing to avoid the linear dependence of the other fixed effect columns of the reporting units.

We've changed how we generate fixed effects such that we now do that when getting the reporting units. This makes sure that we only generate the fixed effects for the categories that we need (ie. only for states where at least one unit has already reported). To make sure that the nonreporting dataframe have the same fixed effects, we manually add the missing categories when generating the nonreporting dataframe.

The nonreporting dataframe can have additional categories (fixed effects that don't appear in the reporting set), but we don't need to worry about those since we select out the features (incl. fixed effects) that we need when fitting and predicting with the model.

## Jira Ticket
[elex-1981](https://arcpublishing.atlassian.net/browse/ELEX-1981)

## Test Steps
To replicate the bug, change line 94 in the `cli.py` to 
```
data_handler.shuffle(upweight={"postal_code": {"AL": 0.01}})
```
and run. This should generate live data where no Alabama county is reporting, which should crash the model. This no longer happens in the new branch.

Also, updated some tests to reflect this change.
`