### PR TITLE
Fix/write district in bounds

### DIFF
--- a/src/elexmodel/distributions/GaussianModel.py
+++ b/src/elexmodel/distributions/GaussianModel.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 from elexmodel.handlers import s3
 from elexmodel.utils import math_utils, pandas_utils
-from elexmodel.utils.constants import AGGREGATE_ORDER
 from elexmodel.utils.file_utils import S3_FILE_PATH, TARGET_BUCKET, convert_df_to_csv
 
 

--- a/src/elexmodel/distributions/GaussianModel.py
+++ b/src/elexmodel/distributions/GaussianModel.py
@@ -217,10 +217,6 @@ class GaussianModel:
                     aggregate,
                     alpha,
                 )
-                # Write columns for preceding aggregates
-                for agg in AGGREGATE_ORDER[: AGGREGATE_ORDER.index(aggregate[-1])]:
-                    if agg in conformalization_data:
-                        gaussian_bounds[agg] = conformalization_data[agg]
                 # Write bounds
                 self._write_gaussian_bounds(
                     gaussian_bounds,

--- a/src/elexmodel/handlers/s3.py
+++ b/src/elexmodel/handlers/s3.py
@@ -66,6 +66,7 @@ class S3CsvUtil(S3Util):
         """
         if not filename.endswith(".csv"):
             filename = f"{filename}.csv"
+        kwargs.setdefault("ContentType", "text/csv")
         super().put(filename, data, **kwargs)
 
     def get(self, filename, load=True, **kwargs):


### PR DESCRIPTION
## Description
On election night in November we realized that the district column of the bounds produced by the GaussianModel of the `precinct-district` model with gaussian prediction interval aggregation method were missing. 

After investigating, I realized that the column should have been missing because the rows in the `bounds.csv` file represent the gaussian model for all precincts (nation-wide) and the second row for all precincts in Virginia (both of which are not district specific). The reason that the `postal_code` for both was `VA` was because we were overwriting that column with data from the conformalization set.

I've removed the code that does the overwriting. But I am curious what that code was supposed to do initially? 

I also added default type for `contentType` as `text/csv` when writing CSVs to s3 in the `S3CsvUtil`. The default set for anything written to s3 in the `S3Util` was as `contentType` `application/json`. And so downloading all these CSVs from the s3 turned the files into json.


## Jira Ticket
[elex-1980](https://arcpublishing.atlassian.net/browse/ELEX-1980)

## Test Steps
In develop branch change line 94 in `cli.py` to `data_handler.shuffle(upweight={'postal_code': {'VA': 100000}})` and run:
```
elexmodel 2022-11-08_USA_G --office_id=H_precinct-district --estimands=gop --geographic_unit_type=precinct-district --pi_method=gaussian --historical --percent_reporting=1 --aggregates=district --save_output=conformalization
```
In `bounds.csv` (you will need to check in `2020-11-03` since historical is `True`) all `postal_code` are overwritten to be `VA`. If you rerun this in the branch the first gaussian bound should have empty postal_code (it is for all precincts, regardless of state).
