### PR TITLE
fixed another fixed effect bug

### DIFF
--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -136,14 +136,17 @@ class CombinedDataHandler(object):
             nonreporting_units = self._expand_fixed_effects(nonreporting_units, self.fixed_effects, drop_first=False)
             # if all units from one fixed effect are reporting they will not appear in the nonreporting_units and won't
             # get a column when we expand the fixed effects on that dataframe. Therefore we add those columns with zero
-            # fixed effects manually. As an example, if we are running a county model using state fixed effects, and 
+            # fixed effects manually. As an example, if we are running a county model using state fixed effects, and
             # all of Delaware's counties are reporting, then no Delaware county will be in nonreporting_units, as a result
             # there will be no column for Delaware in the expanded fixed effects of nonreporting_units.
             for expanded_fixed_effect in self.expanded_fixed_effects:
                 if expanded_fixed_effect not in nonreporting_units.columns:
                     missing_expanded_fixed_effects.append(expanded_fixed_effect)
 
-            missing_expanded_fixed_effects_df = pd.DataFrame(np.zeros((nonreporting_units.shape[0], len(missing_expanded_fixed_effects))), columns=missing_expanded_fixed_effects)
+            missing_expanded_fixed_effects_df = pd.DataFrame(
+                np.zeros((nonreporting_units.shape[0], len(missing_expanded_fixed_effects))),
+                columns=missing_expanded_fixed_effects,
+            )
             # if we use this method to add the missing expanded fixed effects because doing it manually
             # ie. nonreporting[expanded_fixed_effect] = 0
             # can throw a fragmentation warning when there are many missing fixed effects.

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -146,7 +146,9 @@ class CombinedDataHandler(object):
             # can throw a fragmentation warning when there are many missing fixed effects.
             # we have to fillna because all other that don't have index 0 will have NaNs for the missing
             # expanded fixed effect columns
-            nonreporting_units = pd.concat([nonreporting_units, missing_expanded_fixed_effects_df], axis=1).fillna(missing_expanded_fixed_effects)
+            nonreporting_units = pd.concat([nonreporting_units, missing_expanded_fixed_effects_df], axis=1).fillna(
+                missing_expanded_fixed_effects
+            )
 
             # if nonreporting_units is empty then the above concat creates a row which has zeroes
             # for the expanded fixed effects and NaN for all other columns. We want to remove that line

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -132,28 +132,22 @@ class CombinedDataHandler(object):
             nonreporting_units["intercept"] = 1
 
         if len(self.fixed_effects) > 0:
-            missing_expanded_fixed_effects = {}
+            missing_expanded_fixed_effects = []
             nonreporting_units = self._expand_fixed_effects(nonreporting_units, self.fixed_effects, drop_first=False)
             # if all units from one fixed effect are reporting they will not appear in the nonreporting_units and won't
             # get a column when we expand the fixed effects on that dataframe. Therefore we add those columns with zero
-            # fixed effects manually.
+            # fixed effects manually. As an example, if we are running a county model using state fixed effects, and 
+            # all of Delaware's counties are reporting, then no Delaware county will be in nonreporting_units, as a result
+            # there will be no column for Delaware in the expanded fixed effects of nonreporting_units.
             for expanded_fixed_effect in self.expanded_fixed_effects:
                 if expanded_fixed_effect not in nonreporting_units.columns:
-                    missing_expanded_fixed_effects[expanded_fixed_effect] = 0
+                    missing_expanded_fixed_effects.append(expanded_fixed_effect)
 
-            missing_expanded_fixed_effects_df = pd.DataFrame(missing_expanded_fixed_effects, index=[0])
+            missing_expanded_fixed_effects_df = pd.DataFrame(np.zeros((nonreporting_units.shape[0], len(missing_expanded_fixed_effects))), columns=missing_expanded_fixed_effects)
             # if we use this method to add the missing expanded fixed effects because doing it manually
+            # ie. nonreporting[expanded_fixed_effect] = 0
             # can throw a fragmentation warning when there are many missing fixed effects.
-            # we have to fillna because all other that don't have index 0 will have NaNs for the missing
-            # expanded fixed effect columns
-            nonreporting_units = pd.concat([nonreporting_units, missing_expanded_fixed_effects_df], axis=1).fillna(
-                missing_expanded_fixed_effects
-            )
-
-            # if nonreporting_units is empty then the above concat creates a row which has zeroes
-            # for the expanded fixed effects and NaN for all other columns. We want to remove that line
-            # this is necessary because the concat above creates a row which has zeroes for the expanded
-            nonreporting_units = nonreporting_units[~nonreporting_units.postal_code.isnull()].reset_index(drop=True)
+            nonreporting_units = nonreporting_units.join(missing_expanded_fixed_effects_df)
 
         nonreporting_units["reporting"] = 0
 

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -139,13 +139,18 @@ class CombinedDataHandler(object):
             # fixed effects manually.
             for expanded_fixed_effect in self.expanded_fixed_effects:
                 if expanded_fixed_effect not in nonreporting_units.columns:
-                    missing_expanded_fixed_effects[expanded_fixed_effect] = [0]
-            missing_expanded_fixed_effects_df = pd.DataFrame(missing_expanded_fixed_effects)
+                    missing_expanded_fixed_effects[expanded_fixed_effect] = 0
+
+            missing_expanded_fixed_effects_df = pd.DataFrame(missing_expanded_fixed_effects, index=[0])
             # if we use this method to add the missing expanded fixed effects because doing it manually
             # can throw a fragmentation warning when there are many missing fixed effects.
-            nonreporting_units = pd.concat([nonreporting_units, missing_expanded_fixed_effects_df], axis=1)
+            # we have to fillna because all other that don't have index 0 will have NaNs for the missing
+            # expanded fixed effect columns
+            nonreporting_units = pd.concat([nonreporting_units, missing_expanded_fixed_effects_df], axis=1).fillna(missing_expanded_fixed_effects)
+
+            # if nonreporting_units is empty then the above concat creates a row which has zeroes
+            # for the expanded fixed effects and NaN for all other columns. We want to remove that line
             # this is necessary because the concat above creates a row which has zeroes for the expanded
-            # fixed effects and NaN for all other columns.
             nonreporting_units = nonreporting_units[~nonreporting_units.postal_code.isnull()].reset_index(drop=True)
 
         nonreporting_units["reporting"] = 0

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -245,6 +245,8 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     assert "county_fips" in combined_data_handler.fixed_effects
     assert len(combined_data_handler.expanded_fixed_effects) == n - 1
 
+    assert not nonreporting_data['county_fips_51009'].isnull().any()
+
 
 def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
     """

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -245,7 +245,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     assert "county_fips" in combined_data_handler.fixed_effects
     assert len(combined_data_handler.expanded_fixed_effects) == n - 1
 
-    assert not nonreporting_data['county_fips_51009'].isnull().any()
+    assert not nonreporting_data["county_fips_51009"].isnull().any()
 
 
 def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):


### PR DESCRIPTION
## Description
The bug surfaced because occasionally the model was producing `NaN` for predictions when being run with fixed effects. After some investigation it turned out this happened when all units that were part of one fixed effect (ie. all counties in a state, when running with a county level model and state level fixed effects) were reporting. 

When generating the expanded fixed effect columns for the non-reporting units we create an additional dataframe for all fixed effects that appear in reporting units but do not appear in non-reporting units (ie. they will not have a column in the expanded non-reporting matrix). We then concatenate the non-reporting dataframe with the missing expanded fixed effects dataframe. The missing expanded fixed effects dataframe has one row (with index `zero`) and a column for every missing fixed effect. Because `pd.concat` concatenates by index, it was only concatenating the row from the missing expanded fixed effects dataframe to the first (index zero) row of the non-reporting dataframe. The other rows were `NaN` and when they were passed into the model the predictions for those rows were `NaN` also.

The solution is to `fillna` the missing expanded fixed effect columns in the non-reporting dataframe after concatenation. 

This was not caught earlier because we replace `NaN` predictions with zero during aggregation. This is to make sure that we properly aggregate states that are not-reporting and state that are reporting entirely (ie. states that do not have a mixed set of units in non-reporting and reporting dataframes). 

It is worth considering whether we should raise an error (or a warning) when any predictions are `NaN`.

## Jira Ticket

https://arcpublishing.atlassian.net/browse/ELEX-2330

## Test Steps
I've added a test that makes sure that no fixed effect columns are `NaN`. If you copy the new assert from the `test` file over to develop and run `tox` it should fail. It doesn't fail in this branch.