### PR TITLE
elex-2333-remove-nonreporting-residuals-column

### DIFF
--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from elexmodel.handlers import s3
 from elexmodel.utils.file_utils import S3_FILE_PATH, TARGET_BUCKET, convert_df_to_csv
 
@@ -56,18 +54,17 @@ class CombinedDataHandler(object):
             ) / reporting_units[f"total_voters_{estimand}"]
 
         reporting_units["reporting"] = 1
+
         return reporting_units
 
     def get_nonreporting_units(self, percent_reporting_threshold, features_to_normalize=[], add_intercept=True):
         """
         Get nonreporting data. These are units where expected vote is less than the percent reporting threshold
         """
-        nonreporting_units = (
-            self.data.query(
-                "percent_expected_vote < @percent_reporting_threshold"
-            )  # not checking if results.isnull() anymore across multiple estimands
-            .reset_index(drop=True)
-            .assign(residuals=np.nan)
+        nonreporting_units = self.data.query(
+            "percent_expected_vote < @percent_reporting_threshold"
+        ).reset_index(  # not checking if results.isnull() anymore across multiple estimands
+            drop=True
         )
 
         nonreporting_units["reporting"] = 0


### PR DESCRIPTION
## Description
There was a blank residuals column being added to the nonreporting_units matrix that was unused. This caused confusion when debugging issues with reporting and non-reporting units. Nonreporting residuals columns do not get fed into the solver (obviously, because they don't exist and its a non-reporting unit).

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2333

## Test Steps
Run model under several settings to make sure nothing breaks. Gaussian v. nonparametric and feature v no feature. And in a multi-state run, with and without fixed effects.
