### PR TITLE
elex-2334-remove-total-voters-columns

### DIFF
--- a/src/elexmodel/distributions/GaussianModel.py
+++ b/src/elexmodel/distributions/GaussianModel.py
@@ -92,14 +92,18 @@ class GaussianModel:
             .apply(
                 lambda x: pd.Series(
                     {
-                        "var_inflate": math_utils.compute_inflate(x[f"total_voters_{estimand}"]),
+                        "var_inflate": math_utils.compute_inflate(x[f"last_election_results_{estimand}"]),
                         "mu_lower_bound": math_utils.weighted_median(
                             x.lower_bounds.values,
-                            (x[f"total_voters_{estimand}"] / np.sum(x[f"total_voters_{estimand}"])).to_numpy(),
+                            (
+                                x[f"last_election_results_{estimand}"] / np.sum(x[f"last_election_results_{estimand}"])
+                            ).to_numpy(),
                         ),
                         "mu_upper_bound": math_utils.weighted_median(
                             x.upper_bounds.values,
-                            (x[f"total_voters_{estimand}"] / np.sum(x[f"total_voters_{estimand}"])).to_numpy(),
+                            (
+                                x[f"last_election_results_{estimand}"] / np.sum(x[f"last_election_results_{estimand}"])
+                            ).to_numpy(),
                         ),
                         "sigma_lower_bound": beta * math_utils.boot_sigma(x.lower_bounds.values, conf=(3 + alpha) / 4),
                         "sigma_upper_bound": beta * math_utils.boot_sigma(x.upper_bounds.values, conf=(3 + alpha) / 4),
@@ -204,7 +208,7 @@ class GaussianModel:
                         ["geographic_unit_fips"]
                         + aggregate
                         + [
-                            f"total_voters_{estimand}",
+                            f"last_election_results_{estimand}",
                             "lower_bounds",
                             "upper_bounds",
                         ]

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -53,7 +53,7 @@ class CombinedDataHandler(object):
         for estimand in self.estimands:
             reporting_units[f"residuals_{estimand}"] = (
                 reporting_units[f"results_{estimand}"] - reporting_units[f"last_election_results_{estimand}"]
-            ) / reporting_units[f"total_voters_{estimand}"]
+            ) / reporting_units[f"last_election_results_{estimand}"]
 
         reporting_units["reporting"] = 1
         return reporting_units

--- a/src/elexmodel/handlers/data/PreprocessedData.py
+++ b/src/elexmodel/handlers/data/PreprocessedData.py
@@ -90,10 +90,8 @@ class PreprocessedDataHandler(object):
 
         for estimand, pointer in estimand_baselines.items():
             baseline_name = f"baseline_{pointer}"
-            preprocessed_data[f"last_election_results_{estimand}"] = preprocessed_data[baseline_name].copy()
-            # TODO: rename total voters column
             # Adding one to prevent zero divison
-            preprocessed_data[f"total_voters_{estimand}"] = preprocessed_data[f"last_election_results_{estimand}"] + 1
+            preprocessed_data[f"last_election_results_{estimand}"] = preprocessed_data[baseline_name].copy() + 1
 
         return preprocessed_data
 

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -55,7 +55,7 @@ class BaseElectionModel(object):
         reporting_units_features = self.featurizer.featurize_fitting_data(reporting_units)
         nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
 
-        weights = reporting_units[f"total_voters_{estimand}"]
+        weights = reporting_units[f"last_election_results_{estimand}"]
         reporting_units_residuals = reporting_units[f"residuals_{estimand}"]
 
         self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
@@ -63,7 +63,7 @@ class BaseElectionModel(object):
         preds = self.qr.predict(nonreporting_units_features)
 
         # multiply by total voters to get unnormalized residuals
-        preds = preds * nonreporting_units[f"total_voters_{estimand}"]
+        preds = preds * nonreporting_units[f"last_election_results_{estimand}"]
 
         # add in last election results to go from residual to number of votes in this election
         # max with results so that predictions are always at least ars large as actual number of votes
@@ -200,7 +200,7 @@ class BaseElectionModel(object):
         # in this function.
         train_data_features = self.featurizer.featurize_fitting_data(train_data)
         train_data_residuals = train_data[f"residuals_{estimand}"]
-        train_data_weights = train_data[f"total_voters_{estimand}"]
+        train_data_weights = train_data[f"last_election_results_{estimand}"]
 
         # fit lower and upper model to training data. ECOS solver is better than SCS.
         lower_qr = QuantileRegressionSolver(solver="ECOS")

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -74,8 +74,8 @@ class GaussianElectionModel(BaseElectionModel):
         upper = prediction_intervals.upper + upper_correction
 
         # un-normalize residuals
-        lower *= nonreporting_units[f"total_voters_{estimand}"]
-        upper *= nonreporting_units[f"total_voters_{estimand}"]
+        lower *= nonreporting_units[f"last_election_results_{estimand}"]
+        upper *= nonreporting_units[f"last_election_results_{estimand}"]
 
         # move from residual to vote space
         # max with nonreporting results so that bounds are at least as large as the # of votes seen
@@ -158,13 +158,13 @@ class GaussianElectionModel(BaseElectionModel):
                 lambda x: pd.Series(
                     {
                         "nonreporting_aggregate_lower_bound": np.sum(
-                            x[f"total_voters_{estimand}"] * x.nonreporting_lower_bounds
+                            x[f"last_election_results_{estimand}"] * x.nonreporting_lower_bounds
                         ),
                         "nonreporting_aggregate_upper_bound": np.sum(
-                            x[f"total_voters_{estimand}"] * x.nonreporting_upper_bounds
+                            x[f"last_election_results_{estimand}"] * x.nonreporting_upper_bounds
                         ),
-                        "nonreporting_weight_sum": np.sum(x[f"total_voters_{estimand}"]),
-                        "nonreporting_weight_ssum": np.sum(np.power(x[f"total_voters_{estimand}"], 2)),
+                        "nonreporting_weight_sum": np.sum(x[f"last_election_results_{estimand}"]),
+                        "nonreporting_weight_ssum": np.sum(np.power(x[f"last_election_results_{estimand}"], 2)),
                     }
                 )
             )

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -32,7 +32,8 @@ class NonparametricElectionModel(BaseElectionModel):
         """
         # calc weights
         weights = (
-            conformalization_data[f"total_voters_{estimand}"] / conformalization_data[f"total_voters_{estimand}"].sum()
+            conformalization_data[f"last_election_results_{estimand}"]
+            / conformalization_data[f"last_election_results_{estimand}"].sum()
         )
         # sort scores and weights by scores
         population_correction = pd.DataFrame({"scores": scores, "weights": weights}).sort_values("scores")
@@ -86,8 +87,8 @@ class NonparametricElectionModel(BaseElectionModel):
         self.nonreporting_upper_bounds = upper
 
         # un-normalize residuals
-        lower *= nonreporting_units[f"total_voters_{estimand}"]
-        upper *= nonreporting_units[f"total_voters_{estimand}"]
+        lower *= nonreporting_units[f"last_election_results_{estimand}"]
+        upper *= nonreporting_units[f"last_election_results_{estimand}"]
 
         # move from residual to vote space
         # max with nonreporting results so that bounds are at least as large as the # of votes seen

--- a/tests/distributions/test_gaussian_model.py
+++ b/tests/distributions/test_gaussian_model.py
@@ -140,7 +140,7 @@ def test_fit():
 
     gaussian_model = GaussianModel(model_settings)
 
-    df = pd.DataFrame({f"total_voters_{estimand}": weights, "lower_bounds": lower, "upper_bounds": upper})
+    df = pd.DataFrame({f"last_election_results_{estimand}": weights, "lower_bounds": lower, "upper_bounds": upper})
 
     # all in the same group
     g = gaussian_model._fit(df, estimand, [], alpha, beta)
@@ -168,7 +168,7 @@ def test_fit():
             "geographic_unit_fips": 1,
             "lower_bounds": a,
             "upper_bounds": a,
-            f"total_voters_{estimand}": weights_a,
+            f"last_election_results_{estimand}": weights_a,
         }
     )
     df_a["group"] = "a"
@@ -178,7 +178,7 @@ def test_fit():
             "geographic_unit_fips": 2,
             "lower_bounds": b,
             "upper_bounds": b,
-            f"total_voters_{estimand}": weights_b,
+            f"last_election_results_{estimand}": weights_b,
         }
     )
     df_b["group"] = "b"
@@ -226,7 +226,7 @@ def test_large_and_small_fit():
             "geographic_unit_fips": 1,
             "lower_bounds": a,
             "upper_bounds": a,
-            f"total_voters_{estimand}": weights_a,
+            f"last_election_results_{estimand}": weights_a,
         }
     )
     df_a["group_2"] = "a"
@@ -236,14 +236,14 @@ def test_large_and_small_fit():
             "geographic_unit_fips": 2,
             "lower_bounds": b,
             "upper_bounds": b,
-            f"total_voters_{estimand}": weights_b,
+            f"last_election_results_{estimand}": weights_b,
         }
     )
     df_b["group_2"] = "b"
     df = pd.concat([df_a, df_b])
     df["group_1"] = "general"
     general = df.lower_bounds.values
-    general_weights = df[f"total_voters_{estimand}"].values
+    general_weights = df[f"last_election_results_{estimand}"].values
 
     alpha = 0.9
     beta = 1

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -218,7 +218,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
     nonreporting_data_features = featurizer.featurize_heldout_data(nonreporting_data)
 
-    assert combined_data_handler.data.shape == (133, 33)
+    assert combined_data_handler.data.shape == (133, 32)
 
     n_expected_columns = 6  # (6 - 1) fixed effects + 1 intercept
     assert reporting_data_features.shape == (133, n_expected_columns)
@@ -247,7 +247,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
     nonreporting_data_features = featurizer.featurize_heldout_data(nonreporting_data)
 
-    assert combined_data_handler.data.shape == (133, 33)
+    assert combined_data_handler.data.shape == (133, 32)
 
     n_expected_columns = 138  # (6 - 1) + (133 - 1) fixed effects + 1 intercept
     assert reporting_data_features.shape == (133, n_expected_columns)
@@ -301,7 +301,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
     nonreporting_data_features = featurizer.featurize_heldout_data(nonreporting_data)
 
-    assert combined_data_handler.data.shape == (133, 33)
+    assert combined_data_handler.data.shape == (133, 32)
 
     n_expected_columns = (n - 1) + 1  # minus 1 for dropped fixed effect, plus 1 for intercept
     assert reporting_data_features.shape == (n, n_expected_columns)
@@ -363,7 +363,7 @@ def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
     nonreporting_data_features = featurizer.featurize_heldout_data(nonreporting_data)
 
-    assert combined_data_handler.data.shape == (2360, 33)
+    assert combined_data_handler.data.shape == (2360, 32)
 
     n_expected_columns = 7  # when n = 100 we get to county 51013 (minus dropped fixed effect, plus intercept)
     assert reporting_data_features.shape == (n, n_expected_columns)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -350,8 +350,7 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
     data = data_handler.get_percent_fully_reported(100)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     result = model_client.get_estimates(
         data,
@@ -411,8 +410,7 @@ def test_not_including_unit_data(model_client, va_governor_county_data, va_gover
     data = data_handler.get_percent_fully_reported(100)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     result = model_client.get_estimates(
         data,
@@ -447,8 +445,7 @@ def test_unexpected_units_no_new_units(model_client, va_governor_precinct_data, 
     data = data_handler.get_percent_fully_reported(100)
 
     preprocessed_data = va_governor_precinct_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     result = model_client.get_estimates(
         data,
@@ -490,8 +487,7 @@ def test_unexpected_units_new_units(model_client, va_governor_county_data, va_go
     data = data_handler.get_percent_fully_reported(100)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     result = model_client.get_estimates(
         data,
@@ -525,8 +521,7 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
     data = data_handler.get_percent_fully_reported(70)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     result = model_client.get_estimates(
         data,
@@ -539,7 +534,6 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
     )
-
     assert result["state_data"].shape == (1, 6)
     assert result["unit_data"].shape == (133, 7)
 
@@ -562,11 +556,11 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
     ]
 
     assert result["state_data"]["postal_code"][0] == "VA"
-    assert result["state_data"]["pred_turnout"][0] == 2587567.0
+    assert result["state_data"]["pred_turnout"][0] == 2587563.0
     assert result["state_data"]["results_turnout"][0] == 1570077.0
     assert result["state_data"]["reporting"][0] == 94.0
-    assert result["state_data"]["lower_0.9_turnout"][0] == 2443878.0
-    assert result["state_data"]["upper_0.9_turnout"][0] == 2683319.0
+    assert result["state_data"]["lower_0.9_turnout"][0] == 2443849.0
+    assert result["state_data"]["upper_0.9_turnout"][0] == 2683348.0
 
 
 def test_get_estimates_no_subunits_reporting(model_client, va_governor_county_data, va_governor_config):
@@ -585,8 +579,8 @@ def test_get_estimates_no_subunits_reporting(model_client, va_governor_county_da
     data = data_handler.get_percent_fully_reported(0)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
+    #   preprocessed_data["last_election_results_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
 
     with pytest.raises(ModelNotEnoughSubunitsException, match="Currently 0 reporting, need at least 20"):
         model_client.get_estimates(
@@ -618,8 +612,7 @@ def test_get_estimates_not_enough_subunits_reporting(model_client, va_governor_c
     data = data_handler.get_percent_fully_reported(10)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     with pytest.raises(ModelNotEnoughSubunitsException, match="Currently 14 reporting, need at least 20"):
         model_client.get_estimates(
@@ -651,8 +644,7 @@ def test_conformalization_data(model_client, va_governor_county_data, va_governo
     data = data_handler.get_percent_fully_reported(70)
 
     preprocessed_data = va_governor_county_data.copy()
-    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy()
-    preprocessed_data["total_voters_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
+    preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
 
     model_client.get_estimates(
         data,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -580,7 +580,6 @@ def test_get_estimates_no_subunits_reporting(model_client, va_governor_county_da
 
     preprocessed_data = va_governor_county_data.copy()
     preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
-    #   preprocessed_data["last_election_results_turnout"] = preprocessed_data["last_election_results_turnout"] + 1
 
     with pytest.raises(ModelNotEnoughSubunitsException, match="Currently 0 reporting, need at least 20"):
         model_client.get_estimates(


### PR DESCRIPTION
## Description
"total_voters_{estimand}" has been removed everywhere. Instead we add in the additional voter (needed to avoid division by 0) into the "last_election_results_{estimand}" columns directly.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2334

## Test Steps
Run model and make sure nothing breaks. Try both gaussian and nonparametric, and no fixed effects v fixed effects = 'postal_code' (this is in a multi-state election test)
