### PR TITLE
elex-2331-nan-warnings

### DIFF
--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -63,13 +63,13 @@ class BaseElectionModel(object):
         # of the reporting units, which are all being tested here.
 
         if reporting_units_features.isnull().values.any():
-            warnings.warn("NaN values in reporting_units_features df")
+            LOG.warning("Warning: NaN values in reporting_units_features")
 
         if reporting_units_residuals.isnull().values.any():
-            warnings.warn("NaN values in reporting_units_residuals")
-
+            LOG.warning("Warning: NaN values in reporting_units_residuals")
+        print(nonreporting_units_features.head())
         if nonreporting_units_features.isnull().values.any():
-            warnings.warn("NaN values in nonreporting_units_features")
+            LOG.warning("Warning: NaN values in nonreporting_units_features")
 
         self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
 

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -58,6 +58,19 @@ class BaseElectionModel(object):
         weights = reporting_units[f"last_election_results_{estimand}"]
         reporting_units_residuals = reporting_units[f"residuals_{estimand}"]
 
+        # check if any Nan values are getting fed into the solver. We don't need to repeat this
+        # for the additional lower/upper bound quantile fittings, as they're just using subsets
+        # of the reporting units, which are all being tested here.
+
+        if reporting_units_features.isnull().values.any():
+            warnings.warn("NaN values in reporting_units_features df")
+
+        if reporting_units_residuals.isnull().values.any():
+            warnings.warn("NaN values in reporting_units_residuals")
+
+        if nonreporting_units_features.isnull().values.any():
+            warnings.warn("NaN values in nonreporting_units_features")
+
         self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
 
         preds = self.qr.predict(nonreporting_units_features)

--- a/tests/models/test_base_election_model.py
+++ b/tests/models/test_base_election_model.py
@@ -52,12 +52,12 @@ def test_nan_data_warning(va_governor_precinct_data):
     with pytest.warns(None):
         model.get_unit_predictions(df1, df2, estimand)
 
-    df1.at[5, f"residuals_{estimand}"] = np.nan
+    df1.loc[5, f"residuals_{estimand}"] = np.nan
     with pytest.warns(UserWarning):
         model.get_unit_predictions(df1, df2, estimand)
 
     df1[f"residuals_{estimand}"] = np.random.choice([0, 1], size=len(df1))
-    df2.at[6, "demo_feature"] = np.nan
+    df2.loc[6, "demo_feature"] = np.nan
     with pytest.warns(UserWarning):
         model.get_unit_predictions(df1, df2, estimand)
 

--- a/tests/models/test_base_election_model.py
+++ b/tests/models/test_base_election_model.py
@@ -26,7 +26,7 @@ def test_fit_model():
     assert all(np.abs(qr.coefficients - [1, 7]) <= TOL)
 
 
-def test_nan_data_warning(va_governor_precinct_data):
+def test_nan_data_warning(va_governor_precinct_data, capsys, caplog):
     """
     This test checks that warnings are given if model (i.e. solver) inputs have Nan
     values. It checks both the features df and residuals for reporting units.
@@ -49,15 +49,11 @@ def test_nan_data_warning(va_governor_precinct_data):
     df2["reporting"] = 0
 
     model.get_unit_predictions(df1, df2, estimand)
+
     with pytest.warns(None):
         model.get_unit_predictions(df1, df2, estimand)
 
     df1.loc[5, f"residuals_{estimand}"] = np.nan
-    with pytest.warns(UserWarning):
-        model.get_unit_predictions(df1, df2, estimand)
-
-    df1[f"residuals_{estimand}"] = np.random.choice([0, 1], size=len(df1))
-    df2.loc[6, "demo_feature"] = np.nan
     with pytest.warns(UserWarning):
         model.get_unit_predictions(df1, df2, estimand)
 


### PR DESCRIPTION
## Description
We want to throw a warning when nan values are fed into the solver. This now checks reporting and nonreporting data that is then fitted. Note, we don't need to check before the additional solver fittings during the conformalization steps, as this is just using subsets of the same data.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2331

## Test Steps
New units tests - run tox.
(also sanity check placement of new warnings)
