### PR TITLE
Elex 2376 add regularization

### DIFF
--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -38,6 +38,7 @@ from elexmodel.utils.file_utils import TARGET_BUCKET  # noqa: E402
 )
 @click.option("--beta", "beta", default=1, type=int, help="manually add variance to Gaussian model")
 @click.option("--robust", "robust", is_flag=True, help="robust prediction intervals for nonparametric model")
+@click.option("--lambda", "lambda", default=0, type=float, help="regularization parameter")
 @click.option(
     "--percent_reporting",
     "percent_reporting",

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -85,7 +85,7 @@ class ModelClient(object):
             raise ValueError("beta is not valid. Has to be either an integer or a float.")
         if not isinstance(robust, bool):
             raise ValueError("robust is not valid. Has to be a boolean.")
-        if not (isinstance(lambda_, float) or isinstance(lambda_, int)) :
+        if not (isinstance(lambda_, float) or isinstance(lambda_, int)):
             raise ValueError("lambda is not valid. It has to be numeric.")
         if lambda_ < 0:
             raise ValueError("lambda is not valid. It has to be greater than zero.")

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -88,7 +88,7 @@ class ModelClient(object):
         if not (isinstance(lambda_, float) or isinstance(lambda_, int)) :
             raise ValueError("lambda is not valid. It has to be numeric.")
         if lambda_ < 0:
-            raise ValueError("lambda_ is not valid. It has to be greater than zero.")
+            raise ValueError("lambda is not valid. It has to be greater than zero.")
         if handle_unreporting not in {"drop", "zero"}:
             raise ValueError("handle_unreporting must be either `drop` or `zero`")
         return True

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -50,6 +50,7 @@ class ModelClient(object):
         pi_method,
         beta,
         robust,
+        lambda_,
         handle_unreporting,
     ):
         offices = config_handler.get_offices()
@@ -84,6 +85,10 @@ class ModelClient(object):
             raise ValueError("beta is not valid. Has to be either an integer or a float.")
         if not isinstance(robust, bool):
             raise ValueError("robust is not valid. Has to be a boolean.")
+        if not (isinstance(lambda_, float) or isinstance(lambda_, int)) :
+            raise ValueError("lambda is not valid. It has to be numeric.")
+        if lambda_ < 0:
+            raise ValueError("lambda_ is not valid. It has to be greater than zero.")
         if handle_unreporting not in {"drop", "zero"}:
             raise ValueError("handle_unreporting must be either `drop` or `zero`")
         return True
@@ -137,6 +142,7 @@ class ModelClient(object):
         pi_method = kwargs.get("pi_method", "nonparametric")
         beta = kwargs.get("beta", 1)
         robust = kwargs.get("robust", False)
+        lambda_ = kwargs.get("lambda", 0)
         save_output = kwargs.get("save_output", ["results"])
         save_results = "results" in save_output
         save_data = "data" in save_output
@@ -150,6 +156,7 @@ class ModelClient(object):
             "geographic_unit_type": geographic_unit_type,
             "beta": beta,
             "robust": robust,
+            "lambda_": lambda_,
             "features": features,
             "fixed_effects": fixed_effects,
             "save_conformalization": save_conformalization,
@@ -170,6 +177,7 @@ class ModelClient(object):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
         states_with_election = config_handler.get_states(office)

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -69,7 +69,9 @@ class Featurizer(object):
         if self.center_features:
             self._center_features(new_fitting_data)
 
+        self.complete_features = []
         if self.add_intercept:
+            self.complete_features += ['intercept']
             self._add_intercept(new_fitting_data)
 
         if len(self.fixed_effects) > 0:
@@ -85,7 +87,7 @@ class Featurizer(object):
             ]
 
         # all features that the model will be fit on
-        self.complete_features = ["intercept"] + self.features + self.expanded_fixed_effects
+        self.complete_features += self.features + self.expanded_fixed_effects
 
         return new_fitting_data[self.complete_features]
 

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -71,7 +71,7 @@ class Featurizer(object):
 
         self.complete_features = []
         if self.add_intercept:
-            self.complete_features += ['intercept']
+            self.complete_features += ["intercept"]
             self._add_intercept(new_fitting_data)
 
         if len(self.fixed_effects) > 0:

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -20,7 +20,7 @@ class BaseElectionModel(object):
     def __init__(self, model_settings={}):
         self.qr = QuantileRegressionSolver(solver="ECOS")
         self.features = model_settings.get("features", [])
-        self.fixed_effects = model_settings.get("fixed_effects", [])
+        self.fixed_effects = model_settings.get("fixed_effects", {})
         self.lambda_ = model_settings.get("lambda_", 0)
         self.features_to_coefficients = {}
         self.featurizer = Featurizer(self.features, self.fixed_effects)

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -40,7 +40,15 @@ class BaseElectionModel(object):
         # where the solver either throws a warning for inaccurate solution or breaks entirely
         # in that case, we catch the error and warning and re-run with normalize_weights false
         try:
-            model.fit(X, y, tau_value=tau, weights=weights, lambda_=self.lambda_, fit_intercept=self.add_intercept, normalize_weights=normalize_weights)
+            model.fit(
+                X,
+                y,
+                tau_value=tau,
+                weights=weights,
+                lambda_=self.lambda_,
+                fit_intercept=self.add_intercept,
+                normalize_weights=normalize_weights,
+            )
         except (UserWarning, cvxpy.error.SolverError):
             LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
             model.fit(X, y, tau_value=tau, weights=weights, lambda_=self.lambda_, normalize_weights=False)
@@ -55,7 +63,9 @@ class BaseElectionModel(object):
         self.featurizer.compute_means_for_centering(reporting_units, nonreporting_units)
         # reporting_units_features and nonreporting_units_features should have the same
         # features. Specifically also the same fixed effect columns.
-        reporting_units_features = self.featurizer.featurize_fitting_data(reporting_units, add_intercept=self.add_intercept)
+        reporting_units_features = self.featurizer.featurize_fitting_data(
+            reporting_units, add_intercept=self.add_intercept
+        )
         nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
 
         weights = reporting_units[f"last_election_results_{estimand}"]

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -65,6 +65,17 @@ def test_adding_intercept():
     assert df.intercept.equals(pd.Series([1, 1, 1, 1]))
 
 
+def test_adding_intercept_complex():
+    features = ["a", "b", "c"]
+    featurizer = Featurizer(features, [])
+    df = pd.DataFrame({"a": [2, 2, 2, 2], "b": [3, 3, 3, 3], "c": [1, 2, 3, 4]})
+
+    df2 = featurizer.featurize_fitting_data(df, center_features=False, add_intercept=True)
+    assert featurizer.add_intercept
+    assert 'intercept' in df2.columns
+    assert 'intercept' in featurizer.complete_features
+
+
 def test_column_names():
     """
     This function tests to make sure that the featurizer returns the right columns

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -72,8 +72,8 @@ def test_adding_intercept_complex():
 
     df2 = featurizer.featurize_fitting_data(df, center_features=False, add_intercept=True)
     assert featurizer.add_intercept
-    assert 'intercept' in df2.columns
-    assert 'intercept' in featurizer.complete_features
+    assert "intercept" in df2.columns
+    assert "intercept" in featurizer.complete_features
 
 
 def test_column_names():

--- a/tests/models/test_base_election_model.py
+++ b/tests/models/test_base_election_model.py
@@ -25,6 +25,25 @@ def test_fit_model():
     assert all(np.abs(qr.coefficients - [1, 7]) <= TOL)
 
 
+def test_get_unit_predictions():
+    model_settings = {"lambda_": 1, "features": ["b"]}
+    model = BaseElectionModel.BaseElectionModel(model_settings)
+    df_X = pd.DataFrame(
+        {
+            "residuals_a": [1, 2, 3, 4],
+            "total_voters_a": [4, 2, 9, 5],
+            "last_election_results_a": [5, 1, 4, 2],
+            "results_a": [0, 0, 0, 1],
+            "b": [2, 3, 4, 5],
+        }
+    )
+    model.get_unit_predictions(df_X, df_X, estimand="a")
+
+    "intercept" in model.features_to_coefficients
+    "b" in model.features_to_coefficients
+    model.features_to_coefficients["intercept"] > 0
+
+
 def test_aggregation_simple():
     """
     This test is a basic test for aggregating reporting votes. We have have two data frames, reporting votes and

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -204,6 +204,7 @@ def test_check_input_parameters_fixed_effect_dict(model_client, va_governor_conf
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,36 +17,10 @@ fixed_effects = []
 pi_method = "gaussian"
 beta = 3
 robust = True
+lambda_ = 0
 handle_unreporting = "drop"
 
 
-@pytest.fixture(scope="session")
-def test_check_default_parameters(model_client, va_governor_config):
-    # checking default parameters using the input_parameters function
-    election_id = "2017-11-07_VA_G"
-    config_handler = ConfigHandler("2017-11-07_VA_G", config=va_governor_config)
-
-    office_id = "G"
-    estimands = ["turnout"]
-    geographic_unit_type = "county"
-    features = []
-    aggregates = ["postal_code"]
-    fixed_effects = []
-
-    model_client._check_input_parameters(
-        config_handler,
-        election_id,
-        geographic_unit_type,
-        office_id,
-        estimands,
-        fixed_effects,
-        aggregates,
-        geographic_unit_type,
-        features,
-    )
-
-
-@pytest.fixture(scope="session")
 def test_check_input_parameters(model_client, va_governor_config):
     election_id = "2017-11-07_VA_G"
     config_handler = ConfigHandler(election_id, config=va_governor_config)
@@ -62,6 +36,7 @@ def test_check_input_parameters(model_client, va_governor_config):
         pi_method,
         beta,
         robust,
+        lambda_,
         handle_unreporting,
     )
 
@@ -82,6 +57,7 @@ def test_check_input_parameters_office(model_client, va_governor_config):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -102,6 +78,7 @@ def test_check_input_parameters_pi_method(model_client, va_governor_config):
             "bad_pi_method",
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -122,6 +99,7 @@ def test_check_input_parameters_estimand(model_client, va_governor_config):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -142,6 +120,7 @@ def test_check_input_parameters_geographic_unit_type(model_client, va_governor_c
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -162,6 +141,7 @@ def test_check_input_parameters_features(model_client, va_governor_config):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -182,6 +162,7 @@ def test_check_input_parameters_aggregates(model_client, va_governor_config):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -202,6 +183,7 @@ def test_check_input_parameters_fixed_effect(model_client, va_governor_config):
             pi_method,
             beta,
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -222,6 +204,7 @@ def test_check_input_parameters_beta(model_client, va_governor_config):
             pi_method,
             "bad_beta",
             robust,
+            lambda_,
             handle_unreporting,
         )
 
@@ -242,6 +225,28 @@ def test_check_input_parameters_robust(model_client, va_governor_config):
             pi_method,
             beta,
             "bad_robust",
+            lambda_,
+            handle_unreporting,
+        )
+
+
+def test_check_input_parameters_lambda_(model_client, va_governor_config):
+    election_id = "2017-11-07_VA_G"
+    config_handler = ConfigHandler(election_id, config=va_governor_config)
+
+    with pytest.raises(ValueError):
+        model_client._check_input_parameters(
+            config_handler,
+            office,
+            estimands,
+            geographic_unit_type,
+            features,
+            aggregates,
+            fixed_effects,
+            pi_method,
+            beta,
+            robust,
+            -1,
             handle_unreporting,
         )
 
@@ -262,6 +267,7 @@ def test_check_input_parameters_handle_unreporting(model_client, va_governor_con
             pi_method,
             beta,
             robust,
+            lambda_,
             "bad_handle_unreporting",
         )
 


### PR DESCRIPTION
## Description
Added a `lambda_` parameter to the CLI and to the client that allows us to specify regularization for our quantile regression model. This will hopefully let us fix situations in which our model is overfit because of fixed effects.

Also added a variable to explicitly set the intercept. This is done for both the `Featurizer` when we add the intercept and for the solver, to avoid regularizing the intercept coefficient.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2376

## Test Steps
Make sure you have elex-solver v1.1.0 installed:
```
pip install elex-solver --upgrade
```

`tox`

First run a model with no features and no fixed effects:
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=turnout --geographic_unit_type=county --pi_method=nonparametric --percent_reporting=5 --aggregates=postal_code
```

Then run a model with fixed effects but no regularization:
```
 elexmodel 2020-11-03_USA_G --office_id=P --estimands=turnout --geographic_unit_type=county --pi_method=nonparametric  --percent_reporting=5 --aggregates=postal_code --fixed_effects=postal_code
```

Then run a model fixed effects and very high regularization:
```
 elexmodel 2020-11-03_USA_G --office_id=P --estimands=turnout --geographic_unit_type=county --pi_method=nonparametric  --percent_reporting=5 --aggregates=postal_code --fixed_effects=postal_code --lambda=1e4
```

You should notice that the output of the last run (with lambda) will be a lot more similar to the run with no fixed effects than with fixed effects because we are regularizing the fixed effect coefficients to zero.