### PR TITLE
feat: add selection of fixed effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 dist/
 .idea/
 .vscode
+*.code-workspace
 venv/
 env/
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Parameters for the CLI tool:
 | percent_reporting    | numeric | 0-100 |
 | historical           | flag    |       |
 | features             | list    | features to include in the model |
-| fixed_effects        | list    | `postal_code`, `county_classification` or `county_fips`, but really any prepared categorical variable |
+| fixed_effects        | dict    | specified as: `{"<fixed_effect_column>: [which fixed effects to include]}`; to include all effects for a column, use `["all"]`; possible values for the fixed effect variable include: `postal_code`, `county_classification` or `county_fips`, but really any prepared categorical variable |
 | aggregates           | list    | list of geographies for which to calculate predictions beyond the original `postal_code`, `county_fips`, `district`, `county_classification` |
 | pi_method            | string  | method for constructing prediction intervals (`nonparametric` or `gaussian`) |
 | beta                 | numeric | variance inflation for `gaussian` model; | 

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -1,6 +1,7 @@
+import json
+
 import click
 from dotenv import find_dotenv, load_dotenv
-import json
 
 load_dotenv(find_dotenv())
 

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -1,5 +1,6 @@
 import click
 from dotenv import find_dotenv, load_dotenv
+import json
 
 load_dotenv(find_dotenv())
 
@@ -14,7 +15,7 @@ from elexmodel.utils.file_utils import TARGET_BUCKET  # noqa: E402
 @click.argument("election_id")
 @click.option("--estimands", "estimands", default=["turnout"], multiple=True)
 @click.option("--office_id", "office_id")
-@click.option("--fixed_effects", "fixed_effects", default=[], multiple=True)
+@click.option("--fixed_effects", "fixed_effects", default={})
 @click.option("--features", default=[], multiple=True)
 @click.option("--aggregates", default=["postal_code", "unit"], multiple=True)
 @click.option(
@@ -76,7 +77,7 @@ def cli(
 
     kwargs["features"] = list(kwargs["features"])
     kwargs["aggregates"] = list(kwargs["aggregates"])
-    kwargs["fixed_effects"] = list(kwargs["fixed_effects"])
+    kwargs["fixed_effects"] = json.loads(kwargs["fixed_effects"])
 
     prediction_intervals = list(prediction_intervals)
 

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -77,7 +77,10 @@ def cli(
 
     kwargs["features"] = list(kwargs["features"])
     kwargs["aggregates"] = list(kwargs["aggregates"])
-    kwargs["fixed_effects"] = json.loads(kwargs["fixed_effects"])
+    try:
+        kwargs["fixed_effects"] = json.loads(kwargs["fixed_effects"])
+    except json.decoder.JSONDecodeError:
+        kwargs["fixed_effects"] = {kwargs["fixed_effects"]: ["all"]}
 
     prediction_intervals = list(prediction_intervals)
 

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -71,9 +71,12 @@ class ModelClient(object):
         if len(invalid_aggregates) > 0:
             raise ValueError(f"Aggregate(s): {invalid_aggregates} not valid. Please check config")
         model_fixed_effects = config_handler.get_fixed_effects(office)
-        invalid_fixed_effects = [
-            fixed_effect for fixed_effect in fixed_effects.keys() if fixed_effect not in model_fixed_effects
-        ]
+        if type(model_fixed_effects) == "dict":
+            invalid_fixed_effects = [
+                fixed_effect for fixed_effect in fixed_effects.keys() if fixed_effect not in model_fixed_effects
+            ]
+        else:
+            invalid_fixed_effects = [fixed_effect for fixed_effect in fixed_effects if fixed_effects not in model_fixed_effects]
         if len(invalid_fixed_effects) > 0:
             raise ValueError(f"Fixed effect(s): {invalid_fixed_effects} not valid. Please check config")
         if pi_method not in {"gaussian", "nonparametric"}:

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -76,7 +76,9 @@ class ModelClient(object):
                 fixed_effect for fixed_effect in fixed_effects.keys() if fixed_effect not in model_fixed_effects
             ]
         else:
-            invalid_fixed_effects = [fixed_effect for fixed_effect in fixed_effects if fixed_effects not in model_fixed_effects]
+            invalid_fixed_effects = [
+                fixed_effect for fixed_effect in fixed_effects if fixed_effects not in model_fixed_effects
+            ]
         if len(invalid_fixed_effects) > 0:
             raise ValueError(f"Fixed effect(s): {invalid_fixed_effects} not valid. Please check config")
         if pi_method not in {"gaussian", "nonparametric"}:

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -71,7 +71,7 @@ class ModelClient(object):
         if len(invalid_aggregates) > 0:
             raise ValueError(f"Aggregate(s): {invalid_aggregates} not valid. Please check config")
         model_fixed_effects = config_handler.get_fixed_effects(office)
-        if type(model_fixed_effects) == "dict":
+        if isinstance(fixed_effects, dict):
             invalid_fixed_effects = [
                 fixed_effect for fixed_effect in fixed_effects.keys() if fixed_effect not in model_fixed_effects
             ]

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -72,7 +72,7 @@ class ModelClient(object):
             raise ValueError(f"Aggregate(s): {invalid_aggregates} not valid. Please check config")
         model_fixed_effects = config_handler.get_fixed_effects(office)
         invalid_fixed_effects = [
-            fixed_effect for fixed_effect in fixed_effects if fixed_effect not in model_fixed_effects
+            fixed_effect for fixed_effect in fixed_effects.keys() if fixed_effect not in model_fixed_effects
         ]
         if len(invalid_fixed_effects) > 0:
             raise ValueError(f"Fixed effect(s): {invalid_fixed_effects} not valid. Please check config")
@@ -133,7 +133,7 @@ class ModelClient(object):
             current_data = pd.DataFrame(current_data[1:], columns=column_values)
         features = kwargs.get("features", [])
         aggregates = kwargs.get("aggregates", ["postal_code", "unit"])
-        fixed_effects = kwargs.get("fixed_effects", [])
+        fixed_effects = kwargs.get("fixed_effects", {})
         pi_method = kwargs.get("pi_method", "nonparametric")
         beta = kwargs.get("beta", 1)
         robust = kwargs.get("robust", False)

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -48,16 +48,15 @@ class Featurizer(object):
         """
         Convert fixed effect columns into dummy variables.
         """
-        # we concatenate the dummy variables with the original fixed effects, since we need the original fixed
-        # effect columns for aggregation.
         original_fixed_effect_columns = df[self.fixed_effect_cols]
         # set non-included values to other as needed
+        fe_df = df.copy()
         for fe, params in self.fixed_effect_params.items():
             if "all" not in params:
-                df[fe] = np.where(~df[fe].isin(params), "other", df[fe])
+                fe_df[fe] = np.where(~fe_df[fe].isin(params), "other", fe_df[fe])
 
         expanded_fixed_effects = pd.get_dummies(
-            df,
+            fe_df,
             columns=self.fixed_effect_cols,
             prefix=self.fixed_effect_cols,
             prefix_sep="_",
@@ -74,6 +73,8 @@ class Featurizer(object):
                 else:
                     cols_to_drop.append(relevant_cols[0])
 
+        # we concatenate the dummy variables with the original fixed effects, since we need the original fixed
+        # effect columns for aggregation.
         return pd.concat(
             [
                 original_fixed_effect_columns,

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -9,12 +9,18 @@ class Featurizer(object):
 
     def __init__(self, features, fixed_effects):
         self.features = features
-        if type(fixed_effects) == "list":
+        if isinstance(fixed_effects, list):
             self.fixed_effect_cols = fixed_effects
             self.fixed_effect_params = {fe: ["all"] for fe in fixed_effects}
         else:
-            self.fixed_effect_params = fixed_effects
             self.fixed_effect_cols = list(fixed_effects.keys())
+            self.fixed_effect_params = {}
+            for fe, params in fixed_effects.items():
+                if params == "all":
+                    self.fixed_effect_params[fe] = ["all"]
+                else:
+                    self.fixed_effect_params[fe] = params
+
         self.expanded_fixed_effects = []
         self.complete_features = None
         self.column_means = None
@@ -47,7 +53,7 @@ class Featurizer(object):
         original_fixed_effect_columns = df[self.fixed_effect_cols]
         # set non-included values to other as needed
         for fe, params in self.fixed_effect_params.items():
-            if params != "all" or "all" not in params:
+            if "all" not in params:
                 df[fe] = np.where(~df[fe].isin(params), "other", df[fe])
 
         expanded_fixed_effects = pd.get_dummies(

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -56,11 +56,7 @@ class Featurizer(object):
                 fe_df[fe] = np.where(~fe_df[fe].isin(params), "other", fe_df[fe])
 
         expanded_fixed_effects = pd.get_dummies(
-            fe_df,
-            columns=self.fixed_effect_cols,
-            prefix=self.fixed_effect_cols,
-            prefix_sep="_",
-            dtype=np.int64
+            fe_df, columns=self.fixed_effect_cols, prefix=self.fixed_effect_cols, prefix_sep="_", dtype=np.int64
         )
 
         # drop first column or "other" column if drop_first is true
@@ -75,12 +71,7 @@ class Featurizer(object):
 
         # we concatenate the dummy variables with the original fixed effects, since we need the original fixed
         # effect columns for aggregation.
-        return pd.concat(
-            [
-                original_fixed_effect_columns,
-                expanded_fixed_effects.drop(cols_to_drop, axis=1)
-            ],
-            axis=1)
+        return pd.concat([original_fixed_effect_columns, expanded_fixed_effects.drop(cols_to_drop, axis=1)], axis=1)
 
     def featurize_fitting_data(self, fitting_data, center_features=True, add_intercept=True):
         """

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -7,10 +7,14 @@ class Featurizer(object):
     Featurizer. Normalizes features, add intercept, expands fixed effects
     """
 
-    def __init__(self, features, fixed_effects: dict):
+    def __init__(self, features, fixed_effects):
         self.features = features
-        self.fixed_effect_params = fixed_effects
-        self.fixed_effect_cols = list(fixed_effects.keys())
+        if type(fixed_effects) == "list":
+            self.fixed_effect_cols = fixed_effects
+            self.fixed_effect_params = {fe: ["all"] for fe in fixed_effects}
+        else:
+            self.fixed_effect_params = fixed_effects
+            self.fixed_effect_cols = list(fixed_effects.keys())
         self.expanded_fixed_effects = []
         self.complete_features = None
         self.column_means = None
@@ -43,8 +47,7 @@ class Featurizer(object):
         original_fixed_effect_columns = df[self.fixed_effect_cols]
         # set non-included values to other as needed
         for fe, params in self.fixed_effect_params.items():
-            print(params)
-            if "all" not in params:
+            if params != "all" or "all" not in params:
                 df[fe] = np.where(~df[fe].isin(params), "other", df[fe])
 
         expanded_fixed_effects = pd.get_dummies(

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -20,7 +20,7 @@ class BaseElectionModel(object):
     def __init__(self, model_settings={}):
         self.qr = QuantileRegressionSolver(solver="ECOS")
         self.features = model_settings.get("features", [])
-        self.fixed_effects = model_settings.get("fixed_effects", [])
+        self.fixed_effects = model_settings.get("fixed_effects", {})
         self.featurizer = Featurizer(self.features, self.fixed_effects)
         self.seed = 4191  # set arbitrarily
 

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -12,7 +12,7 @@ def compute_testing_mean_for_centering():
     Test whether computing the column mean for centering works.
     """
     features = ["a", "b", "c"]
-    featurizer = Featurizer(features, [])
+    featurizer = Featurizer(features, {})
 
     # test with one dataframe
     df = pd.DataFrame({"a": [1, 1, 1, 1], "b": [2, 2, 2, 2], "c": [3, 3, 3, 3], "d": [1, 2, 3, 4]})
@@ -35,7 +35,7 @@ def test_centering_features():
     Test whether centering the features works
     """
     features = ["a", "b"]
-    featurizer = Featurizer(features, [])
+    featurizer = Featurizer(features, {})
 
     # test with one dataframe
     df = pd.DataFrame({"a": [1, 2, 3], "b": [2, 4, 9]})
@@ -54,7 +54,7 @@ def test_centering_features():
 
 def test_adding_intercept():
     features = ["a", "b", "c"]
-    featurizer = Featurizer(features, [])
+    featurizer = Featurizer(features, {})
 
     # test with one dataframe
     df = pd.DataFrame({"a": [2, 2, 2, 2], "b": [3, 3, 3, 3], "c": [1, 2, 3, 4]})
@@ -70,7 +70,7 @@ def test_column_names():
     This function tests to make sure that the featurizer returns the right columns
     """
     features = ["a", "b", "c"]
-    fixed_effects = ["fe_a"]
+    fixed_effects = {"fe_a": ["all"]}
     featurizer = Featurizer(features, fixed_effects)
 
     df_fitting = pd.DataFrame(
@@ -128,12 +128,12 @@ def test_column_names():
 
 
 def test_expanding_fixed_effects_basic():
-    fixed_effects = ["c1"]
+    fixed_effects = {"c1": ["all"]}
     featurizer = Featurizer([], fixed_effects)
     df = pd.DataFrame({"c1": ["a", "b", "b", "c"], "c2": ["w", "x", "y", "z"], "c3": [2, 4, 1, 9]})
     expanded = featurizer._expand_fixed_effects(df, drop_first=True)
     pd.testing.assert_frame_equal(
-        expanded,
+        expanded.sort_index(axis=1),
         pd.DataFrame(
             {
                 "c2": ["w", "x", "y", "z"],
@@ -142,13 +142,13 @@ def test_expanding_fixed_effects_basic():
                 "c1_c": [0, 0, 0, 1],
                 "c1": ["a", "b", "b", "c"],
             }
-        ),
+        ).sort_index(axis=1),
     )
 
     df = pd.DataFrame({"c1": ["a", "b", "b", "c"], "c2": ["w", "x", "y", "z"], "c3": [2, 4, 1, 9]})
     expanded = featurizer._expand_fixed_effects(df, drop_first=False)
     pd.testing.assert_frame_equal(
-        expanded,
+        expanded.sort_index(axis=1),
         pd.DataFrame(
             {
                 "c2": ["w", "x", "y", "z"],
@@ -158,14 +158,14 @@ def test_expanding_fixed_effects_basic():
                 "c1_c": [0, 0, 0, 1],
                 "c1": ["a", "b", "b", "c"],
             }
-        ),
+        ).sort_index(axis=1),
     )
 
-    fixed_effects = ["c1", "c2"]
+    fixed_effects = {"c1": ["all"], "c2": "all"}
     featurizer = Featurizer([], fixed_effects)
     expanded = featurizer._expand_fixed_effects(df, drop_first=True)
     pd.testing.assert_frame_equal(
-        expanded,
+        expanded.sort_index(axis=1),
         pd.DataFrame(
             {
                 "c3": [2, 4, 1, 9],
@@ -177,7 +177,7 @@ def test_expanding_fixed_effects_basic():
                 "c1": ["a", "b", "b", "c"],
                 "c2": ["w", "x", "y", "z"],
             }
-        ),
+        ).sort_index(axis=1),
     )
 
 
@@ -212,7 +212,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     reporting_data = combined_data_handler.get_reporting_units(99)
     nonreporting_data = combined_data_handler.get_nonreporting_units(99)
 
-    featurizer = Featurizer([], ["county_classification"])
+    featurizer = Featurizer([], {"county_classification": "all"})
     featurizer.compute_means_for_centering(reporting_data, nonreporting_data)
 
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
@@ -227,7 +227,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     assert "county_classification_nova" in reporting_data_features.columns
     assert "county_classification_nova" in nonreporting_data_features.columns
 
-    assert "county_classification" in featurizer.fixed_effects
+    assert "county_classification" in featurizer.fixed_effect_cols
     assert len(featurizer.expanded_fixed_effects) == 5  # 6 - 1
 
     combined_data_handler = CombinedDataHandler(
@@ -238,7 +238,7 @@ def test_generate_fixed_effects(va_governor_county_data):
         handle_unreporting="drop",
     )
 
-    featurizer = Featurizer([], ["county_classification", "county_fips"])
+    featurizer = Featurizer([], {"county_classification": ["all"], "county_fips": ["all"]})
     featurizer.compute_means_for_centering(reporting_data, nonreporting_data)
 
     reporting_data = combined_data_handler.get_reporting_units(99)
@@ -259,8 +259,8 @@ def test_generate_fixed_effects(va_governor_county_data):
     assert "county_fips_51790" in reporting_data_features.columns
     assert "county_fips_51790" in nonreporting_data_features.columns
 
-    assert "county_classification" in featurizer.fixed_effects
-    assert "county_fips" in featurizer.fixed_effects
+    assert "county_classification" in featurizer.fixed_effect_cols
+    assert "county_fips" in featurizer.fixed_effect_cols
     assert len(featurizer.expanded_fixed_effects) == 137  # 6 + 133 - 2
 
 
@@ -295,7 +295,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     reporting_data = combined_data_handler.get_reporting_units(99)
     nonreporting_data = combined_data_handler.get_nonreporting_units(99)
 
-    featurizer = Featurizer([], ["county_fips"])
+    featurizer = Featurizer([], {"county_fips": ["all"]})
     featurizer.compute_means_for_centering(reporting_data, nonreporting_data)
 
     reporting_data_features = featurizer.featurize_fitting_data(reporting_data)
@@ -320,7 +320,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
         "county_fips_51790" not in nonreporting_data_features.columns
     )  # not in here because not in featurizer.complete_features
 
-    assert "county_fips" in featurizer.fixed_effects
+    assert "county_fips" in featurizer.fixed_effect_cols
     assert len(featurizer.expanded_fixed_effects) == n - 1
 
     assert not reporting_data_features["county_fips_51009"].isnull().any()
@@ -387,5 +387,5 @@ def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
         "county_fips_51790" not in nonreporting_data_features.columns
     )  # not in here because not in featurizer.complete_features
 
-    assert "county_fips" in featurizer.fixed_effects
+    assert "county_fips" in featurizer.fixed_effect_cols
     assert len(featurizer.expanded_fixed_effects) == 7 - 1

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -161,7 +161,7 @@ def test_expanding_fixed_effects_basic():
         ).sort_index(axis=1),
     )
 
-    fixed_effects = {"c1": ["all"], "c2": "all"}
+    fixed_effects = {"c1": ["all"], "c2": ["all"]}
     featurizer = Featurizer([], fixed_effects)
     expanded = featurizer._expand_fixed_effects(df, drop_first=True)
     pd.testing.assert_frame_equal(
@@ -174,6 +174,57 @@ def test_expanding_fixed_effects_basic():
                 "c2_x": [0, 1, 0, 0],
                 "c2_y": [0, 0, 1, 0],
                 "c2_z": [0, 0, 0, 1],
+                "c1": ["a", "b", "b", "c"],
+                "c2": ["w", "x", "y", "z"],
+            }
+        ).sort_index(axis=1),
+    )
+
+
+def test_expand_fixed_effects_selective():
+    fixed_effects = {"c1": ["a", "b"]}
+    featurizer = Featurizer([], fixed_effects)
+    df = pd.DataFrame({"c1": ["a", "b", "b", "c"], "c2": ["w", "x", "y", "z"], "c3": [2, 4, 1, 9]})
+    expanded = featurizer._expand_fixed_effects(df, drop_first=True)
+    pd.testing.assert_frame_equal(
+        expanded.sort_index(axis=1),
+        pd.DataFrame(
+            {
+                "c2": ["w", "x", "y", "z"],
+                "c3": [2, 4, 1, 9],
+                "c1_a": [1, 0, 0, 0],
+                "c1_b": [0, 1, 1, 0],
+                "c1": ["a", "b", "b", "c"],
+            }
+        ).sort_index(axis=1),
+    )
+
+    expanded = featurizer._expand_fixed_effects(df, drop_first=False)
+    pd.testing.assert_frame_equal(
+        expanded.sort_index(axis=1),
+        pd.DataFrame(
+            {
+                "c2": ["w", "x", "y", "z"],
+                "c3": [2, 4, 1, 9],
+                "c1_a": [1, 0, 0, 0],
+                "c1_b": [0, 1, 1, 0],
+                "c1_other": [0, 0, 0, 1],
+                "c1": ["a", "b", "b", "c"],
+            }
+        ).sort_index(axis=1),
+    )
+
+    fixed_effects = {"c1": ["a"], "c2": ["w", "x"]}
+    featurizer = Featurizer([], fixed_effects)
+    expanded = featurizer._expand_fixed_effects(df, drop_first=True)
+    pd.testing.assert_frame_equal(
+        expanded.sort_index(axis=1),
+        pd.DataFrame(
+            {
+                "c3": [2, 4, 1, 9],
+                "c1_a": [1, 0, 0, 0],
+                "c2_w": [1, 0, 0, 0],
+                "c2_x": [0, 1, 0, 0],
                 "c1": ["a", "b", "b", "c"],
                 "c2": ["w", "x", "y", "z"],
             }


### PR DESCRIPTION
## Description
Allows you to select which fixed effects are included in the model. All other values for that variable are coded as "other". You do so with a fixed_effects parameter that looks like:
```
'{"state_postal": ["PA", "CA"], "county_classification": ["all"]}'
```
(it needs to have the quotes in that order on the CLI - just pass as a dictionary to the client)

This change is _kinda_ backward compatible in that you can still pass `Featurizer` a list of fixed effects and it will assume that you want all FEs for everything in the list. Additionally, you can pass 1 set of fixed effects in the old way to the cli, *but* you cannot pass multiple `--fixed_effects` parameters.

## Jira Ticket
elex-2375

## Test Steps
```
elexmodel 2017-11-07_VA_G --estimands=dem --office_id=G --geographic_unit_type=precinct --aggregates=county_classification --aggregates=postal_code --fixed_effects='{"county_classification": ["nova", "southside"]}' --percent_reporting 10 --features=ethnicity_european --features=ethnicity_hispanic_and_portuguese

elexmodel 2021-01-05_GA_G --office_id=S_precinct --estimands=dem --geographic_unit_type=precinct --pi_method=gaussian --percent_reporting=20 --fixed_effects='{"county_fips": ["13311", "13319"], "county_classification": ["all"]}'

```