### PR TITLE
fix checking new fixed effect inputs

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -77,7 +77,7 @@ class ModelClient(object):
             ]
         else:
             invalid_fixed_effects = [
-                fixed_effect for fixed_effect in fixed_effects if fixed_effects not in model_fixed_effects
+                fixed_effect for fixed_effect in fixed_effects if fixed_effect not in model_fixed_effects
             ]
         if len(invalid_fixed_effects) > 0:
             raise ValueError(f"Fixed effect(s): {invalid_fixed_effects} not valid. Please check config")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -186,7 +186,7 @@ def test_check_input_parameters_aggregates(model_client, va_governor_config):
         )
 
 
-def test_check_input_parameters_fixed_effect(model_client, va_governor_config):
+def test_check_input_parameters_fixed_effect_list(model_client, va_governor_config):
     election_id = "2017-11-07_VA_G"
     config_handler = ConfigHandler(election_id, config=va_governor_config)
 
@@ -205,6 +205,24 @@ def test_check_input_parameters_fixed_effect(model_client, va_governor_config):
             handle_unreporting,
         )
 
+def test_check_input_parameters_fixed_effect_dict(model_client, va_governor_config):
+    election_id = "2017-11-07_VA_G"
+    config_handler = ConfigHandler(election_id, config=va_governor_config)
+
+    with pytest.raises(ValueError):
+        model_client._check_input_parameters(
+            config_handler,
+            office,
+            estimands,
+            geographic_unit_type,
+            features,
+            aggregates,
+            {"bad_fixed_effect": ['a', 'b']},
+            pi_method,
+            beta,
+            robust,
+            handle_unreporting,
+        )
 
 def test_check_input_parameters_beta(model_client, va_governor_config):
     election_id = "2017-11-07_VA_G"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,6 +205,7 @@ def test_check_input_parameters_fixed_effect_list(model_client, va_governor_conf
             handle_unreporting,
         )
 
+
 def test_check_input_parameters_fixed_effect_dict(model_client, va_governor_config):
     election_id = "2017-11-07_VA_G"
     config_handler = ConfigHandler(election_id, config=va_governor_config)
@@ -217,12 +218,13 @@ def test_check_input_parameters_fixed_effect_dict(model_client, va_governor_conf
             geographic_unit_type,
             features,
             aggregates,
-            {"bad_fixed_effect": ['a', 'b']},
+            {"bad_fixed_effect": ["a", "b"]},
             pi_method,
             beta,
             robust,
             handle_unreporting,
         )
+
 
 def test_check_input_parameters_beta(model_client, va_governor_config):
     election_id = "2017-11-07_VA_G"


### PR DESCRIPTION
## Description
Fixed small bug where we were checking whether a list was in another list instead of whether an element of the first list was in the other list. This was always false, and causing us to not be able to run the model with fixed effects if passed in through the normal way.

## Jira Ticket

## Test Steps
`tox`
Added a unit test for the dictionary case. This was not caught because the first unit tests in `test_client` are not being run, the fix for that is in this PR: https://github.com/washingtonpost/elex-live-model/pull/42
