### PR TITLE
changed name in client

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -147,7 +147,7 @@ class ModelClient(object):
         pi_method = kwargs.get("pi_method", "nonparametric")
         beta = kwargs.get("beta", 1)
         robust = kwargs.get("robust", False)
-        lambda_ = kwargs.get("lambda", 0)
+        lambda_ = kwargs.get("lambda_", 0)
         save_output = kwargs.get("save_output", ["results"])
         save_results = "results" in save_output
         save_data = "data" in save_output


### PR DESCRIPTION
## Description
Had to change the name of the regularization parameter in the model from `lambda` to `lambda_` because otherwise it can't be used/called from an outside repo (like the modeltestbed or the in the future the importer) since python interprets the `lambda` to be a `lambda` function 🙃 

## Jira Ticket

## Test Steps
`tox` literally nothing breaks
