### PR TITLE
Fix unit tests

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,6 +389,7 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
         geographic_unit_type,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
+        save_output=[]
     )
 
     assert result["state_data"].shape == (1, 6)
@@ -450,6 +451,7 @@ def test_not_including_unit_data(model_client, va_governor_county_data, va_gover
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
+        save_output=[]
     )
     assert "unit_data" not in result.keys()
 
@@ -485,6 +487,7 @@ def test_unexpected_units_no_new_units(model_client, va_governor_precinct_data, 
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
+        save_output=[]
     )
     va_counties_count = va_governor_precinct_data[["county_fips"]].drop_duplicates().shape[0]
     assert result["county_data"].shape[0] == va_counties_count
@@ -527,6 +530,7 @@ def test_unexpected_units_new_units(model_client, va_governor_county_data, va_go
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
+        save_output=[]
     )
     va_counties_count = va_governor_county_data[["county_fips"]].drop_duplicates().shape[0]
     assert result["county_data"].shape[0] == va_counties_count + unexpected_units
@@ -560,6 +564,7 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         geographic_unit_type,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
+        save_output=[]
     )
     assert result["state_data"].shape == (1, 6)
     assert result["unit_data"].shape == (133, 7)
@@ -619,6 +624,7 @@ def test_get_estimates_no_subunits_reporting(model_client, va_governor_county_da
             geographic_unit_type,
             raw_config=va_governor_config,
             preprocessed_data=preprocessed_data,
+            save_output=[]
         )
 
 
@@ -651,6 +657,7 @@ def test_get_estimates_not_enough_subunits_reporting(model_client, va_governor_c
             geographic_unit_type,
             raw_config=va_governor_config,
             preprocessed_data=preprocessed_data,
+            save_output=[]
         )
 
 
@@ -683,6 +690,7 @@ def test_conformalization_data(model_client, va_governor_county_data, va_governo
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
         pi_method="gaussian",
+        save_output=[]
     )
 
     conform_unit = model_client.get_all_conformalization_data_unit()
@@ -710,6 +718,7 @@ def test_conformalization_data(model_client, va_governor_county_data, va_governo
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
         pi_method="nonparametric",
+        save_output=[]
     )
 
     conform_unit = model_client.get_all_conformalization_data_unit()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,7 +389,7 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
         geographic_unit_type,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
-        save_output=[]
+        save_output=[],
     )
 
     assert result["state_data"].shape == (1, 6)
@@ -451,7 +451,7 @@ def test_not_including_unit_data(model_client, va_governor_county_data, va_gover
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
-        save_output=[]
+        save_output=[],
     )
     assert "unit_data" not in result.keys()
 
@@ -487,7 +487,7 @@ def test_unexpected_units_no_new_units(model_client, va_governor_precinct_data, 
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
-        save_output=[]
+        save_output=[],
     )
     va_counties_count = va_governor_precinct_data[["county_fips"]].drop_duplicates().shape[0]
     assert result["county_data"].shape[0] == va_counties_count
@@ -530,7 +530,7 @@ def test_unexpected_units_new_units(model_client, va_governor_county_data, va_go
         aggregates=aggregates,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
-        save_output=[]
+        save_output=[],
     )
     va_counties_count = va_governor_county_data[["county_fips"]].drop_duplicates().shape[0]
     assert result["county_data"].shape[0] == va_counties_count + unexpected_units
@@ -564,7 +564,7 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         geographic_unit_type,
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
-        save_output=[]
+        save_output=[],
     )
     assert result["state_data"].shape == (1, 6)
     assert result["unit_data"].shape == (133, 7)
@@ -624,7 +624,7 @@ def test_get_estimates_no_subunits_reporting(model_client, va_governor_county_da
             geographic_unit_type,
             raw_config=va_governor_config,
             preprocessed_data=preprocessed_data,
-            save_output=[]
+            save_output=[],
         )
 
 
@@ -657,7 +657,7 @@ def test_get_estimates_not_enough_subunits_reporting(model_client, va_governor_c
             geographic_unit_type,
             raw_config=va_governor_config,
             preprocessed_data=preprocessed_data,
-            save_output=[]
+            save_output=[],
         )
 
 
@@ -690,7 +690,7 @@ def test_conformalization_data(model_client, va_governor_county_data, va_governo
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
         pi_method="gaussian",
-        save_output=[]
+        save_output=[],
     )
 
     conform_unit = model_client.get_all_conformalization_data_unit()
@@ -718,7 +718,7 @@ def test_conformalization_data(model_client, va_governor_county_data, va_governo
         raw_config=va_governor_config,
         preprocessed_data=preprocessed_data,
         pi_method="nonparametric",
-        save_output=[]
+        save_output=[],
     )
 
     conform_unit = model_client.get_all_conformalization_data_unit()


### PR DESCRIPTION
## Description
pytest unit tests break because pytest does not have access to the environment variables to create the s3 path for. Our unit tests were writing results to s3 since we were using the default `save_output` parameter, which defaults to `['results']`. We now pass in an empty list to `save_output` to avoid writing to s3 from the unit tests.

## Test Steps
No unit tests should fail when running:
`pytest` or `tox`
