### PR TITLE
Remove model settings

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -306,7 +306,6 @@ class ModelClient(object):
                         alpha,
                         alpha_to_unit_prediction_intervals[alpha].conformalization,
                         estimand,
-                        model_settings,
                     )
                     self.all_conformalization_data_agg_dict[alpha][estimand] = model.get_all_conformalization_data_agg()
 

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -106,7 +106,6 @@ class GaussianElectionModel(BaseElectionModel):
         alpha,
         conformalization_data,
         estimand,
-        model_settings,
     ):
         """
         Get aggregate prediction intervals. Adjust aggregate prediction intervals based on Gaussian models
@@ -128,7 +127,7 @@ class GaussianElectionModel(BaseElectionModel):
         )
 
         # fit gaussian model in aggregate case
-        gaussian_model = GaussianModel(model_settings).fit(
+        gaussian_model = GaussianModel(self.model_settings).fit(
             conformalization_data,
             reporting_units,
             nonreporting_units,

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -119,7 +119,6 @@ class NonparametricElectionModel(BaseElectionModel):
         alpha,
         conformalization_data,
         estimand,
-        model_settings,
     ):
         """
         Get aggregate prediction intervals. In the non-parametric case prediction intervals just sum.

--- a/tests/models/test_nonparametric_election_model.py
+++ b/tests/models/test_nonparametric_election_model.py
@@ -113,14 +113,10 @@ def test_aggregate_prediction_intervals(va_governor_precinct_data):
     df3 = df[2000:].copy()
     df3["reporting"] = 1
 
-    intervals = model.get_aggregate_prediction_intervals(
-        df1, df2, df3, ["postal_code"], alpha, None, estimand
-    )
+    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["postal_code"], alpha, None, estimand)
     assert 2535685.0 == intervals.lower[0]  # total based on summing csv
     assert 2535685.0 == intervals.upper[0]  # total based on summing csv
 
-    intervals = model.get_aggregate_prediction_intervals(
-        df1, df2, df3, ["county_fips"], alpha, None, estimand
-    )
+    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["county_fips"], alpha, None, estimand)
     assert 10664.0 == intervals.lower[0]  # first county based on summing csv
     assert 10664.0 == intervals.upper[0]  # first county based on summing csv

--- a/tests/models/test_nonparametric_election_model.py
+++ b/tests/models/test_nonparametric_election_model.py
@@ -83,7 +83,7 @@ def test_aggregate_prediction_intervals_simple():
         }
     )
 
-    intervals = model.get_aggregate_prediction_intervals(df1, df3, df2, ["c1"], alpha, None, estimand, model_settings)
+    intervals = model.get_aggregate_prediction_intervals(df1, df3, df2, ["c1"], alpha, None, estimand)
 
     assert np.array_equal(np.asarray([12, 19, 8, 6, 3]), intervals.lower)
     assert np.array_equal(np.asarray([26, 19, 17, 6, 9]), intervals.upper)
@@ -114,13 +114,13 @@ def test_aggregate_prediction_intervals(va_governor_precinct_data):
     df3["reporting"] = 1
 
     intervals = model.get_aggregate_prediction_intervals(
-        df1, df2, df3, ["postal_code"], alpha, None, estimand, model_settings
+        df1, df2, df3, ["postal_code"], alpha, None, estimand
     )
     assert 2535685.0 == intervals.lower[0]  # total based on summing csv
     assert 2535685.0 == intervals.upper[0]  # total based on summing csv
 
     intervals = model.get_aggregate_prediction_intervals(
-        df1, df2, df3, ["county_fips"], alpha, None, estimand, model_settings
+        df1, df2, df3, ["county_fips"], alpha, None, estimand
     )
     assert 10664.0 == intervals.lower[0]  # first county based on summing csv
     assert 10664.0 == intervals.upper[0]  # first county based on summing csv


### PR DESCRIPTION
## Description
We are passing the model settings dictionary into the constructor. We should just use `self.model_settings` when passing the settings to GaussianModel instead of having to pass them `get_aggregate_prediction_intervals` when the function is called. 

Task: Remove model_settings as a parameter for all implementations of `get_aggregate_prediction_intervals`.

Note: I also made these changes within the Nonparametric election model in order to ensure that combined unit tests run smoothly.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2264

## Test Steps
1. `pip install elex-model`
2. `pip install -r requirements.txt`
3. `pip install -r requirements-dev.txt`
4. `Create a .env file with the variables specified in README`
5. `tox`