### PR TITLE
ELEX-2402-random-seed-model

### DIFF
--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -3,14 +3,13 @@ import json
 import click
 from dotenv import find_dotenv, load_dotenv
 
+load_dotenv(find_dotenv())
+
 from elexmodel.client import HistoricalModelClient, ModelClient  # noqa: E402
 from elexmodel.handlers import s3  # noqa: E402
 from elexmodel.handlers.data.LiveData import MockLiveDataHandler  # noqa: E402
 from elexmodel.utils.constants import VALID_AGGREGATES_MAPPING  # noqa: E402
 from elexmodel.utils.file_utils import TARGET_BUCKET  # noqa: E402
-
-load_dotenv(find_dotenv())
-
 
 @click.command()
 @click.argument("election_id")

--- a/src/elexmodel/utils/math_utils.py
+++ b/src/elexmodel/utils/math_utils.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import decimal
 
 import numpy as np
 from scipy.stats import bootstrap
@@ -80,16 +81,24 @@ def compute_error(true, pred, type_="mae"):
         return mape.round(decimals=2)
 
 
+def normal_round(x, n):
+    """
+    rounds postive values up rather than down, alternative to banker's rounding which is used in python .round
+    """
+    decimal.getcontext().rounding = decimal.ROUND_HALF_UP
+    return float(decimal.Decimal(x).quantize(decimal.Decimal("0." + "0" * n)))
+
+
 def compute_frac_within_pi(lower, upper, results):
     """
     computes coverage of prediction intervals.
     """
-    return np.mean((upper >= results) & (lower <= results)).round(decimals=2)
+    return normal_round(np.mean((upper >= results) & (lower <= results)), 2)
 
 
 def compute_mean_pi_length(lower, upper, pred):
     """
-    computes average relative length of prediction interval
+    Computes average relative length of prediction interval
     """
     # we add 1 since pred can be literally zero
-    return np.mean((upper - lower) / (pred + 1)).round(decimals=2)
+    return normal_round(np.mean((upper - lower) / (pred + 1)), 2)


### PR DESCRIPTION
## Description
**Original error description:** In ‘test_redo.py’ and ‘test_vary_params.py’ the unit tests that use the ‘frac_within_pi’ and ‘mean_pi_length’ are currently commented out. That is because those tests rely on some of the randomness in the model (computes CI’s) so won’t be the same value run to run. We need to set a model seed that only affects the unit tests - so those values are the same each time.

**New error description:** The error appears to not be caused by the randomness of the model. This is because the error only occurs during the ‘mean_pi_length’ calculation when the result (on either side, rounded to the second decimal) ends in a 5. The python `.round `function uses "banker's rounding" which is causing the following issues.

ERROR: assert 0.3 == 0.29 <--> 0.296 == 0.295
ERROR: assert 0.26 == 0.25 <--> assert 0.255 == 0.256
ERROR: assert 0.557 == 0.558 <--> 0.56 == 0.558

To resolve this error, a corresponding PR is opened in [elex-live-model-testbed](https://github.com/WPMedia/elex-live-model-testbed/pull/15) to update the tests. This PR will update math_utils.py.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2402