### PR TITLE
ELEX-2857-winsorize-error

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -832,10 +832,12 @@ def test_winsorize_intervals(model_client, va_governor_county_data, va_config):
     non_winsorize_results = non_winsorize_results.get("state_data")
 
     assert (
-        winsorize_results.loc[:, "lower_0.9_turnout"].values[0]
+        winsorize_results.loc[:, "lower_0.9_turnout"].values[0] 
+        + winsorize_results.loc[:, "lower_0.9_turnout"].values[0] * 0.01
         >= non_winsorize_results.loc[:, "lower_0.9_turnout"].values[0]
     )
     assert (
         winsorize_results.loc[:, "upper_0.9_turnout"].values[0]
-        <= non_winsorize_results.loc[:, "upper_0.9_turnout"].values[0]
+        <= non_winsorize_results.loc[:, "upper_0.9_turnout"].values[0] 
+        + non_winsorize_results.loc[:, "upper_0.9_turnout"].values[0] * 0.01
     )


### PR DESCRIPTION
## Description
In `test_client.py::test_winsorize_intervals`, the check to ensure that the intervals are <=/=> when winsorized compared to when not winsorized would fail occasionally (about once every 10 times) for a difference that is about 0.04% of the predicted data (ex 2441554.0 vs 2442544.0). This would affect the github actions tests for other PRs sometimes. To resolve this, this PR makes the bounds a bit more forgiving (by 1%) for the test.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2857

## Test Steps
tox