### PR TITLE
feat: upgrade to python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("click<8.1", "elex-solver<2", "pandas<1.5.0", "boto3<2", "python-dotenv==0.19.2")
+INSTALL_REQUIRES = ("click<8.1", "elex-solver<2", "pandas<1.5.0", "boto3<2", "python-dotenv==0.19.2", "scipy==1.10.1")
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{3}
+envlist=py3.10
 skipdist=True
 
 [base]


### PR DESCRIPTION
## Description
We use python 3.10 in the new pipeline, which wasn't working with our current model setup. This changes our tox setup to use 3.10 and pins `scipy` to a version that works.

## Jira Ticket

## Test Steps
Unit and integration tests