### PR TITLE
Added generalized model parameters to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,21 @@ Parameters for the CLI tool:
 | fixed_effects        | dict    | specified as: `{"<fixed_effect_column>: [which fixed effects to include]}`; to include all effects for a column, use `["all"]`; possible values for the fixed effect variable include: `postal_code`, `county_classification` or `county_fips`, but really any prepared categorical variable |
 | aggregates           | list    | list of geographies for which to calculate predictions beyond the original `postal_code`, `county_fips`, `district`, `county_classification` |
 | pi_method            | string  | method for constructing prediction intervals (`nonparametric` or `gaussian`) |
-| beta                 | numeric | variance inflation for `gaussian` model; | 
-| robust               | flag    | flag for larger set of prediction intervals in the nonparametric case |
+| model_parameters     | dict    | dictionary of model specific parameters e.g. `--model_parameters='{"robust":"True"}'` |
 | save_output          | list    | `results`, `data`, `config` |
 | unexpected_units     | int     | number of unexpected units to simulate; only used for testing and does not work with historical run |
 
 Note: When running the model with multiple fixed effects, make sure they are not linearly dependent. For example, `county_fips` and `county_classification` are linearly dependent when run together. That's because every county is in one county class, so all the fixed effect columns of the counties in the county class sum up to the fixed effect column of that county class.
+
+#### Model Parameters
+Some model types have specific model parameters that can be included.
+
+| Name      | Type    | Acceptable values           | model |
+|-----------|---------|-----------------------------|-------|
+| lambda    | numeric | 0-inf                       | all |
+| robust    | boolean | larger prediction intervals | `nonparametric` |
+| beta      | numeric | variance inflation          | `gaussian` |
+| winsorize | boolean | winsorize std estimate      | `gaussian` |
 
 ### Python
 

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -160,10 +160,6 @@ class ModelClient:
         aggregates = kwargs.get("aggregates", DEFAULT_AGGREGATES[office])
         fixed_effects = kwargs.get("fixed_effects", {})
         pi_method = kwargs.get("pi_method", "nonparametric")
-        beta = model_parameters.get("beta", 1)
-        winsorize = model_parameters.get("winsorize", False)
-        robust = model_parameters.get("robust", False)
-        lambda_ = model_parameters.get("lambda_", 0)
         save_output = kwargs.get("save_output", ["results"])
         save_results = "results" in save_output
         save_data = "data" in save_output
@@ -175,14 +171,11 @@ class ModelClient:
             "election_id": election_id,
             "office": office,
             "geographic_unit_type": geographic_unit_type,
-            "beta": beta,
-            "winsorize": winsorize,
-            "robust": robust,
-            "lambda_": lambda_,
             "features": features,
             "fixed_effects": fixed_effects,
             "save_conformalization": save_conformalization,
         }
+        model_settings.update(model_parameters)
 
         LOG.info("Getting config: %s", election_id)
         config_handler = ConfigHandler(

--- a/src/elexmodel/distributions/GaussianModel.py
+++ b/src/elexmodel/distributions/GaussianModel.py
@@ -17,7 +17,8 @@ class GaussianModel:
         self.election_id = model_settings.get("election_id")
         self.office = model_settings.get("office")
         self.geographic_unit_type = model_settings.get("geographic_unit_type")
-        self.model_settings = model_settings
+        self.winsorize = model_settings.get("winsorize", False)
+        self.beta = model_settings.get("beta", 1)
 
     def _empty_gaussian_model(self, conformalization_data, aggregate):
         """
@@ -106,13 +107,13 @@ class GaussianModel:
                                 x[f"last_election_results_{estimand}"] / np.sum(x[f"last_election_results_{estimand}"])
                             ).to_numpy(),
                         ),
-                        "sigma_lower_bound": self.model_settings["beta"]
+                        "sigma_lower_bound": self.beta
                         * math_utils.boot_sigma(
-                            x.lower_bounds.values, conf=(3 + alpha) / 4, winsorize=self.model_settings["winsorize"]
+                            x.lower_bounds.values, conf=(3 + alpha) / 4, winsorize=self.winsorize
                         ),
-                        "sigma_upper_bound": self.model_settings["beta"]
+                        "sigma_upper_bound": self.beta
                         * math_utils.boot_sigma(
-                            x.upper_bounds.values, conf=(3 + alpha) / 4, winsorize=self.model_settings["winsorize"]
+                            x.upper_bounds.values, conf=(3 + alpha) / 4, winsorize=self.winsorize
                         ),
                     }
                 )


### PR DESCRIPTION
## Description
[Previously](https://github.com/washingtonpost/elex-live-model/pull/64) we had changed how we pass model specific parameters. Instead of having to define and deal with each of the model specific parameters separately, we now use a dictionary that can have any key, value pair for a model parameter and it's value. This means that if we add a parameter in the future we don't need to create variables for it in the client but it can be passed directly to the model using `model_settings`.

We had forgotten to add this functionality to the cli, which I do with this PR. I also updated the model client a bit to take full advantage of this change and updated the `GaussianModel` for that too.

## Jira Ticket

## Test Steps
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=dem --geographic_unit_type=county --pi_method=nonparametric --percent_reporting=20 --model_parameters='{"robust":"True"}'
```
and 
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=dem --geographic_unit_type=county --pi_method=gaussian --percent_reporting=20 --model_parameters='{"winsorize":"True", "beta": 1, "lambda": 100}'
```
Unit tests have not changed and should all still pass with `Tox`