### PR TITLE
Elex 2766 separate out conformalization models

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -37,7 +37,6 @@ class ModelClient:
 
     def __init__(self):
         super().__init__()
-        self.model = None
         self.all_conformalization_data_unit_dict = defaultdict(dict)
         self.all_conformalization_data_agg_dict = defaultdict(dict)
 
@@ -223,13 +222,13 @@ class ModelClient:
         )
 
         if pi_method == "nonparametric":
-            self.model = NonparametricElectionModel(model_settings=model_settings)
+            model = NonparametricElectionModel(model_settings=model_settings)
         elif pi_method == "gaussian":
-            self.model = GaussianElectionModel(model_settings=model_settings)
+            model = GaussianElectionModel(model_settings=model_settings)
 
         minimum_reporting_units_max = 0
         for alpha in prediction_intervals:
-            minimum_reporting_units = self.model.get_minimum_reporting_units(alpha)
+            minimum_reporting_units = model.get_minimum_reporting_units(alpha)
             if minimum_reporting_units > minimum_reporting_units_max:
                 minimum_reporting_units_max = minimum_reporting_units
 
@@ -261,22 +260,22 @@ class ModelClient:
         )
 
         for estimand in estimands:
-            unit_predictions = self.model.get_unit_predictions(reporting_units, nonreporting_units, estimand)
+            unit_predictions = model.get_unit_predictions(reporting_units, nonreporting_units, estimand)
             results_handler.add_unit_predictions(estimand, unit_predictions)
             # gets prediciton intervals for each alpha
             alpha_to_unit_prediction_intervals = {}
             for alpha in prediction_intervals:
-                alpha_to_unit_prediction_intervals[alpha] = self.model.get_unit_prediction_intervals(
+                alpha_to_unit_prediction_intervals[alpha] = model.get_unit_prediction_intervals(
                     results_handler.reporting_units, results_handler.nonreporting_units, alpha, estimand
                 )
-                if isinstance(self.model, ConformalElectionModel): 
-                    self.all_conformalization_data_unit_dict[alpha][estimand] = self.model.get_all_conformalization_data_unit()
+                if isinstance(model, ConformalElectionModel): 
+                    self.all_conformalization_data_unit_dict[alpha][estimand] = model.get_all_conformalization_data_unit()
             
             results_handler.add_unit_intervals(estimand, alpha_to_unit_prediction_intervals)
 
             for aggregate in results_handler.aggregates:
                 aggregate_list = self.get_aggregate_list(office, aggregate)
-                estimates_df = self.model.get_aggregate_predictions(
+                estimates_df = model.get_aggregate_predictions(
                     results_handler.reporting_units,
                     results_handler.nonreporting_units,
                     results_handler.unexpected_units,
@@ -285,7 +284,7 @@ class ModelClient:
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:
-                    alpha_to_agg_prediction_intervals[alpha] = self.model.get_aggregate_prediction_intervals(
+                    alpha_to_agg_prediction_intervals[alpha] = model.get_aggregate_prediction_intervals(
                         results_handler.reporting_units,
                         results_handler.nonreporting_units,
                         results_handler.unexpected_units,
@@ -294,8 +293,8 @@ class ModelClient:
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
                     )
-                    if isinstance(self.model, ConformalElectionModel):
-                        self.all_conformalization_data_agg_dict[alpha][estimand] = self.model.get_all_conformalization_data_agg()
+                    if isinstance(model, ConformalElectionModel):
+                        self.all_conformalization_data_agg_dict[alpha][estimand] = model.get_all_conformalization_data_agg()
 
                 # get all of the prediction intervals here
                 results_handler.add_agg_predictions(

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -37,6 +37,7 @@ class ModelClient:
 
     def __init__(self):
         super().__init__()
+        self.model = None
         self.all_conformalization_data_unit_dict = defaultdict(dict)
         self.all_conformalization_data_agg_dict = defaultdict(dict)
 
@@ -222,13 +223,13 @@ class ModelClient:
         )
 
         if pi_method == "nonparametric":
-            model = NonparametricElectionModel(model_settings=model_settings)
+            self.model = NonparametricElectionModel(model_settings=model_settings)
         elif pi_method == "gaussian":
-            model = GaussianElectionModel(model_settings=model_settings)
+            self.model = GaussianElectionModel(model_settings=model_settings)
 
         minimum_reporting_units_max = 0
         for alpha in prediction_intervals:
-            minimum_reporting_units = model.get_minimum_reporting_units(alpha)
+            minimum_reporting_units = self.model.get_minimum_reporting_units(alpha)
             if minimum_reporting_units > minimum_reporting_units_max:
                 minimum_reporting_units_max = minimum_reporting_units
 
@@ -260,22 +261,22 @@ class ModelClient:
         )
 
         for estimand in estimands:
-            unit_predictions = model.get_unit_predictions(reporting_units, nonreporting_units, estimand)
+            unit_predictions = self.model.get_unit_predictions(reporting_units, nonreporting_units, estimand)
             results_handler.add_unit_predictions(estimand, unit_predictions)
             # gets prediciton intervals for each alpha
             alpha_to_unit_prediction_intervals = {}
             for alpha in prediction_intervals:
-                alpha_to_unit_prediction_intervals[alpha] = model.get_unit_prediction_intervals(
+                alpha_to_unit_prediction_intervals[alpha] = self.model.get_unit_prediction_intervals(
                     results_handler.reporting_units, results_handler.nonreporting_units, alpha, estimand
                 )
-                if isinstance(model, ConformalElectionModel): 
-                    self.all_conformalization_data_unit_dict[alpha][estimand] = model.get_all_conformalization_data_unit()
+                if isinstance(self.model, ConformalElectionModel): 
+                    self.all_conformalization_data_unit_dict[alpha][estimand] = self.model.get_all_conformalization_data_unit()
             
             results_handler.add_unit_intervals(estimand, alpha_to_unit_prediction_intervals)
 
             for aggregate in results_handler.aggregates:
                 aggregate_list = self.get_aggregate_list(office, aggregate)
-                estimates_df = model.get_aggregate_predictions(
+                estimates_df = self.model.get_aggregate_predictions(
                     results_handler.reporting_units,
                     results_handler.nonreporting_units,
                     results_handler.unexpected_units,
@@ -284,7 +285,7 @@ class ModelClient:
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:
-                    alpha_to_agg_prediction_intervals[alpha] = model.get_aggregate_prediction_intervals(
+                    alpha_to_agg_prediction_intervals[alpha] = self.model.get_aggregate_prediction_intervals(
                         results_handler.reporting_units,
                         results_handler.nonreporting_units,
                         results_handler.unexpected_units,
@@ -293,8 +294,8 @@ class ModelClient:
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
                     )
-                    if isinstance(model, ConformalElectionModel):
-                        self.all_conformalization_data_agg_dict[alpha][estimand] = model.get_all_conformalization_data_agg()
+                    if isinstance(self.model, ConformalElectionModel):
+                        self.all_conformalization_data_agg_dict[alpha][estimand] = self.model.get_all_conformalization_data_agg()
 
                 # get all of the prediction intervals here
                 results_handler.add_agg_predictions(

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -9,6 +10,7 @@ from elexmodel.handlers.data.CombinedData import CombinedDataHandler
 from elexmodel.handlers.data.ModelResults import ModelResultsHandler
 from elexmodel.handlers.data.PreprocessedData import PreprocessedDataHandler
 from elexmodel.logging import initialize_logging
+from elexmodel.models.ConformalElectionModel import ConformalElectionModel
 from elexmodel.models.GaussianElectionModel import GaussianElectionModel
 from elexmodel.models.NonparametricElectionModel import NonparametricElectionModel
 from elexmodel.utils.constants import AGGREGATE_ORDER, DEFAULT_AGGREGATES, VALID_AGGREGATES_MAPPING
@@ -35,8 +37,8 @@ class ModelClient:
 
     def __init__(self):
         super().__init__()
-        self.conformalization_data_unit_dict = None
-        self.conformalization_data_agg_dict = None
+        self.all_conformalization_data_unit_dict = defaultdict(dict)
+        self.all_conformalization_data_agg_dict = defaultdict(dict)
 
     def _check_input_parameters(
         self,
@@ -104,28 +106,6 @@ class ModelClient:
             raise ValueError("handle_unreporting must be either `drop` or `zero`")
         return True
 
-    def get_all_conformalization_data_unit(self):
-        """
-        This function collects the conformalization data from a model run. It produces a dictionary
-        with two types of data (in the gaussian case): the conformalization points that a
-        distribution is fit to, and the parameters of the resulting guassian distribution.
-        In this unit-level function, the information for one distribution is returned
-        (all units combined). It returns None if get_estimates isn't called, as the
-        values they pull out are generated in that function.
-        """
-        return self.all_conformalization_data_unit_dict
-
-    def get_all_conformalization_data_agg(self):
-        """
-        This function collects the conformalization data from a model run. It produces a dictionary
-        with two types of data (in the gaussian case): the conformalization points that a distribution is
-        fit to, and the parameters of the resulting guassian distribution. In the agg case,
-        distributions for each state (in a multi-state model) are returned. This functions
-        return None if get_estimates isn't called, as the
-        values they pull out are generated in that function.
-        """
-        return self.all_conformalization_data_agg_dict
-
     def get_aggregate_list(self, office, aggregate):
         default_aggregate = DEFAULT_AGGREGATES[office]
         base_aggregate = default_aggregate[:-1]  # remove unit
@@ -164,6 +144,7 @@ class ModelClient:
         save_results = "results" in save_output
         save_data = "data" in save_output
         save_config = "config" in save_output
+        # saving conformalization data only makes sense if a ConformalElectionModel is used
         save_conformalization = "conformalization" in save_output
         handle_unreporting = kwargs.get("handle_unreporting", "drop")
 
@@ -231,16 +212,12 @@ class ModelClient:
         unexpected_units = data.get_unexpected_units(percent_reporting_threshold, aggregates)
 
         LOG.info(
-            "Model parameters: \n geographic_unit_type: %s, prediction intervals: %s, \
-                percent reporting threshold: %s, features: %s, pi_method: %s, aggregates: %s, \
-                fixed effects: %s, model settings: %s",
-            geographic_unit_type,
+            "Model parameters: \n prediction intervals: %s, percent reporting threshold: %s, \
+                pi_method: %s, aggregates: %s, model settings: %s",
             prediction_intervals,
             percent_reporting_threshold,
-            features,
             pi_method,
             aggregates,
-            fixed_effects,
             model_settings,
         )
 
@@ -282,8 +259,6 @@ class ModelClient:
             aggregates, prediction_intervals, reporting_units, nonreporting_units, unexpected_units
         )
 
-        self.all_conformalization_data_unit_dict = {alpha: {} for alpha in prediction_intervals}
-        self.all_conformalization_data_agg_dict = {alpha: {} for alpha in prediction_intervals}
         for estimand in estimands:
             unit_predictions = model.get_unit_predictions(reporting_units, nonreporting_units, estimand)
             results_handler.add_unit_predictions(estimand, unit_predictions)
@@ -293,8 +268,9 @@ class ModelClient:
                 alpha_to_unit_prediction_intervals[alpha] = model.get_unit_prediction_intervals(
                     results_handler.reporting_units, results_handler.nonreporting_units, alpha, estimand
                 )
-                self.all_conformalization_data_unit_dict[alpha][estimand] = model.get_all_conformalization_data_unit()
-
+                if isinstance(model, ConformalElectionModel): 
+                    self.all_conformalization_data_unit_dict[alpha][estimand] = model.get_all_conformalization_data_unit()
+            
             results_handler.add_unit_intervals(estimand, alpha_to_unit_prediction_intervals)
 
             for aggregate in results_handler.aggregates:
@@ -314,10 +290,11 @@ class ModelClient:
                         results_handler.unexpected_units,
                         aggregate_list,
                         alpha,
-                        alpha_to_unit_prediction_intervals[alpha].conformalization,
+                        alpha_to_unit_prediction_intervals[alpha],
                         estimand,
                     )
-                    self.all_conformalization_data_agg_dict[alpha][estimand] = model.get_all_conformalization_data_agg()
+                    if isinstance(model, ConformalElectionModel):
+                        self.all_conformalization_data_agg_dict[alpha][estimand] = model.get_all_conformalization_data_agg()
 
                 # get all of the prediction intervals here
                 results_handler.add_agg_predictions(

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -141,7 +141,7 @@ class BaseElectionModel:
         """
         pass
 
-    def get_coefficients(self):
+    def get_coefficients(self) -> dict:
         """
         Returns a dictionary of feature/fixed effect names to the coefficients
         These coefficients are for the point prediciton only.

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -18,6 +18,12 @@ class BaseElectionModel:
         self.add_intercept = True
         self.seed = model_settings.get("seed", 4191)
 
+    def get_minimum_reporting_units(self, alpha: float) -> int:
+        """
+        Returns the minimum number of units necessary to run the model
+        """
+        return 10
+
     def get_unit_predictions(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, estimand: str, *kwargs) -> np.ndarray:
         """
         Generates and returns unit level predictions

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -1,94 +1,31 @@
 import logging
-import math
-import warnings
 from collections import namedtuple
 
-import cvxpy
+import pandas as pd
 import numpy as np
-from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
-
-from elexmodel.handlers.data.Featurizer import Featurizer
-
-warnings.filterwarnings("error", category=UserWarning, module="cvxpy")
-
-PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper", "conformalization"], defaults=(None,) * 3)
 
 LOG = logging.getLogger(__name__)
 
+PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper"], defaults=(None,) * 2)
+
 
 class BaseElectionModel:
-    def __init__(self, model_settings={}):
-        self.qr = QuantileRegressionSolver(solver="ECOS")
+    def __init__(self, model_settings: dict):
         self.features = model_settings.get("features", [])
         self.fixed_effects = model_settings.get("fixed_effects", {})
-        self.lambda_ = model_settings.get("lambda_", 0)
+        self.model_settings = model_settings
         self.features_to_coefficients = {}
-        self.featurizer = Featurizer(self.features, self.fixed_effects)
         self.add_intercept = True
-        self.seed = 4191  # set arbitrarily
+        self.seed = model_settings.get("seed", 4191)
 
-    def fit_model(self, model, df_X, df_y, tau, weights, normalize_weights):
+    def get_unit_predictions(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, estimand: str, *kwargs) -> np.ndarray:
         """
-        Fits the quantile regression for the model
+        Generates and returns unit level predictions
         """
-        X = df_X.values
-        y = df_y.values
-        weights = weights.values
+        pass
 
-        # normalizing weights speed up solution by a lot. However, if the relative size
-        # of the smallest weight is too close to zero, it can lead to numerical instability
-        # where the solver either throws a warning for inaccurate solution or breaks entirely
-        # in that case, we catch the error and warning and re-run with normalize_weights false
-        try:
-            model.fit(
-                X,
-                y,
-                tau_value=tau,
-                weights=weights,
-                lambda_=self.lambda_,
-                fit_intercept=self.add_intercept,
-                normalize_weights=normalize_weights,
-            )
-        except (UserWarning, cvxpy.error.SolverError):
-            LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
-            model.fit(X, y, tau_value=tau, weights=weights, lambda_=self.lambda_, normalize_weights=False)
-
-    def get_unit_predictions(self, reporting_units, nonreporting_units, estimand):
-        """
-        Produces unit level predictions. Fits quantile regression to reporting data, applies
-        it to nonreporting data. The features are specified in model_settings.
-        """
-        # compute the means of both reporting_units and nonreporting_units for centering (part of featurizing)
-        # we want them both, since together they are the subunit population
-        self.featurizer.compute_means_for_centering(reporting_units, nonreporting_units)
-        # reporting_units_features and nonreporting_units_features should have the same
-        # features. Specifically also the same fixed effect columns.
-        reporting_units_features = self.featurizer.featurize_fitting_data(
-            reporting_units, add_intercept=self.add_intercept
-        )
-        nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
-
-        weights = reporting_units[f"last_election_results_{estimand}"]
-        reporting_units_residuals = reporting_units[f"residuals_{estimand}"]
-
-        self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
-        self.features_to_coefficients = dict(zip(self.featurizer.complete_features, self.qr.coefficients))
-
-        preds = self.qr.predict(nonreporting_units_features)
-
-        # multiply by total voters to get unnormalized residuals
-        preds = preds * nonreporting_units[f"last_election_results_{estimand}"]
-
-        # add in last election results to go from residual to number of votes in this election
-        # max with results so that predictions are always at least ars large as actual number of votes
-        preds = np.maximum(
-            preds + nonreporting_units[f"last_election_results_{estimand}"], nonreporting_units[f"results_{estimand}"]
-        )
-
-        # round since we don't need the artificial precision
-        return preds.round(decimals=0)
-
-    def _get_reporting_aggregate_votes(self, reporting_units, unexpected_units, aggregate, estimand):
+    
+    def _get_reporting_aggregate_votes(self, reporting_units: pd.DataFrame, unexpected_units: pd.DataFrame, aggregate: list, estimand: str, *kwargs) -> pd.DataFrame:
         """
         Aggregate reporting votes by aggregate (ie. postal_code, county_fips etc.). This function
         adds reporting data and reporting unexpected data by aggregate. Note that all unexpected units -
@@ -132,7 +69,7 @@ class BaseElectionModel:
 
         return aggregate_votes
 
-    def _get_nonreporting_aggregate_votes(self, nonreporting_units, aggregate):
+    def _get_nonreporting_aggregate_votes(self, nonreporting_units: pd.DataFrame, aggregate: list, *kwargs) -> pd.DataFrame:
         """
         Aggregate nonreporting votes by aggregate (ie. postal_code, county_fips etc.). Note that all unexpected
         units - whether or not they are fully reporting - are handled in "_get_reporting_aggregate_votes" above
@@ -141,7 +78,7 @@ class BaseElectionModel:
 
         return aggregate_nonreporting_units_known_votes
 
-    def get_aggregate_predictions(self, reporting_units, nonreporting_units, unexpected_units, aggregate, estimand):
+    def get_aggregate_predictions(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, unexpected_units: pd.DataFrame, aggregate: list, estimand: str, *kwargs) -> pd.DataFrame:
         """
         Aggregate predictions and results by aggregate (ie. postal_code, county_fips etc.). Add results from reporting
         and reporting unexpected units and then sum in the predictions from nonreporting units.
@@ -151,9 +88,7 @@ class BaseElectionModel:
 
         # these are subunits that are not already counted
         aggregate_preds = (
-            nonreporting_units.groupby(aggregate)
-            .sum()
-            .reset_index(drop=False)
+            self._get_nonreporting_aggregate_votes(nonreporting_units, aggregate)
             .rename(
                 columns={
                     f"pred_{estimand}": f"pred_only_{estimand}",
@@ -187,80 +122,22 @@ class BaseElectionModel:
         )
 
         return aggregate_data
-
-    def get_unit_prediction_interval_bounds(self, reporting_units, nonreporting_units, conf_frac, alpha, estimand):
+    
+    def get_unit_prediction_intervals(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, alpha: float, estimand: str) -> PredictionIntervals:
         """
-        Get unadjusted unit prediction intervals. Splits reporting data into training data and conformalization data,
-        fits lower and upper quantile regression using training data and apply to both conformalization data
-        and nonreporting data to get conformalization lower/upper bounds and nonreporting lower/upper bounds.
-        Returns unadjusted bounds for nonreporting dat and conformalization data including bounds.
+        Generates and returns unit level prediction intervals
         """
-        # split reporting data into training and conformalization data
-        # seed is set during initialization, to make sure we always get the same
-        # training/conformalization split for each alpha of one run
-        reporting_units_shuffled = reporting_units.sample(frac=1, random_state=self.seed).reset_index(drop=True)
-
-        upper_bound = (1 + alpha) / 2
-        lower_bound = (1 - alpha) / 2
-
-        train_rows = math.floor(reporting_units.shape[0] * conf_frac)
-        train_data = reporting_units_shuffled[:train_rows].reset_index(drop=True)
-
-        # specifying self.features extracts the correct columns and makes sure they are in the correct
-        # order. Necessary when fitting and predicting on the model.
-        # the fixed effects in train_data will be a subset of the fixed effect of reporting_units since all
-        # units from one fixed effect category might be in the conformalization data. Note that we are
-        # overwritting featurizer.expanded_fixed_effects by doing this (which is what we want), since we
-        # want the expanded_fixed_effects from train_data to be used by conformalization_data and nonreporting_data
-        # in this function.
-        train_data_features = self.featurizer.featurize_fitting_data(train_data, add_intercept=self.add_intercept)
-        train_data_residuals = train_data[f"residuals_{estimand}"]
-        train_data_weights = train_data[f"last_election_results_{estimand}"]
-
-        # fit lower and upper model to training data. ECOS solver is better than SCS.
-        lower_qr = QuantileRegressionSolver(solver="ECOS")
-        self.fit_model(lower_qr, train_data_features, train_data_residuals, lower_bound, train_data_weights, True)
-
-        upper_qr = QuantileRegressionSolver(solver="ECOS")
-        self.fit_model(upper_qr, train_data_features, train_data_residuals, upper_bound, train_data_weights, True)
-
-        # apply to conformalization data. Conformalization bounds will later tell us how much to adjust lower/upper
-        # bounds for nonreporting data.
-        conformalization_data = reporting_units_shuffled[train_rows:].reset_index(drop=True)
-        # conformalization features will be the same as the features in train_data
-        conformalization_data_features = self.featurizer.featurize_heldout_data(conformalization_data)
-
-        # we are interested in f(X) - r
-        # since later conformity scores care about deviation of bounds from residuals
-        conformalization_lower_bounds = (
-            lower_qr.predict(conformalization_data_features) - conformalization_data[f"residuals_{estimand}"].values
-        )
-        conformalization_upper_bounds = conformalization_data[f"residuals_{estimand}"].values - upper_qr.predict(
-            conformalization_data_features
-        )
-
-        # save conformalization bounds for later
-        conformalization_data["upper_bounds"] = conformalization_upper_bounds
-        conformalization_data["lower_bounds"] = conformalization_lower_bounds
-
-        # apply lower/upper models to nonreporting data
-        # now the features of the nonreporting_units will be the same as the train_data features
-        # they might differ slightly from the features used when fitting the median prediction
-        nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
-        nonreporting_lower_bounds = lower_qr.predict(nonreporting_units_features)
-        nonreporting_upper_bounds = upper_qr.predict(nonreporting_units_features)
-
-        return PredictionIntervals(nonreporting_lower_bounds, nonreporting_upper_bounds, conformalization_data)
-
-    def get_unit_prediction_intervals(self):
         pass
 
-    def get_aggregate_prediction_intervals(self):
+    def get_aggregate_prediction_intervals(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, unexpected_units: pd.DataFrame, aggregate: list, alpha: float, *kwargs) -> PredictionIntervals:
+        """
+        Generates and returns aggregate prediction intervals for arbitrary aggregates
+        """
         pass
 
     def get_coefficients(self):
         """
-        Returns a dictionary of feature/fixed effect names to the quantile regression coefficients
-        These coefficients are for the point prediciton only, not for the lower or upper intervals models.
+        Returns a dictionary of feature/fixed effect names to the coefficients
+        These coefficients are for the point prediciton only.
         """
         return self.features_to_coefficients

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 
 import cvxpy
 import numpy as np
+import pandas as pd
 from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
 
 from elexmodel.models import BaseElectionModel
@@ -18,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 
 class ConformalElectionModel(BaseElectionModel.BaseElectionModel):
-    def __init__(self, model_settings={}):
+    def __init__(self, model_settings: dict):
         super(ConformalElectionModel, self).__init__(model_settings)
         self.qr = QuantileRegressionSolver(solver="ECOS")
         self.featurizer = Featurizer(self.features, self.fixed_effects)
@@ -31,7 +32,7 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel):
         pass
 
 
-    def fit_model(self, model, df_X, df_y, tau, weights, normalize_weights):
+    def fit_model(self, model: QuantileRegressionSolver, df_X: pd.DataFrame, df_y: pd.Series, tau: float, weights: pd.Series, normalize_weights: bool):
         """
         Fits the quantile regression for the model
         """
@@ -57,7 +58,7 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel):
             LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
             model.fit(X, y, tau_value=tau, weights=weights, lambda_=self.lambda_, normalize_weights=False)
 
-    def get_unit_predictions(self, reporting_units, nonreporting_units, estimand):
+    def get_unit_predictions(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, estimand: str) -> pd.Series:
         """
         Produces unit level predictions. Fits quantile regression to reporting data, applies
         it to nonreporting data. The features are specified in model_settings.
@@ -92,7 +93,7 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel):
         # round since we don't need the artificial precision
         return preds.round(decimals=0)
 
-    def get_unit_prediction_interval_bounds(self, reporting_units, nonreporting_units, conf_frac, alpha, estimand):
+    def get_unit_prediction_interval_bounds(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, conf_frac: float, alpha: float, estimand: str) -> PredictionIntervals:
         """
         Get unadjusted unit prediction intervals. Splits reporting data into training data and conformalization data,
         fits lower and upper quantile regression using training data and apply to both conformalization data

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -17,11 +17,12 @@ PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper", "conf
 LOG = logging.getLogger(__name__)
 
 
-class ConformalElectionModel(BaseElectionModel):
+class ConformalElectionModel(BaseElectionModel.BaseElectionModel):
     def __init__(self, model_settings={}):
         super(ConformalElectionModel, self).__init__(model_settings)
         self.qr = QuantileRegressionSolver(solver="ECOS")
         self.featurizer = Featurizer(self.features, self.fixed_effects)
+        self.lambda_ = model_settings.get("lambda_", 0)
 
     def _compute_conf_frac(self) -> float:
         """
@@ -155,10 +156,17 @@ class ConformalElectionModel(BaseElectionModel):
 
         return PredictionIntervals(nonreporting_lower_bounds, nonreporting_upper_bounds, conformalization_data)
 
-    def get_unit_prediction_intervals(self):
+    def get_all_conformalization_data_unit(self):
+        """
+        Returns conformalization data at the unit level
+        Conformalization data is adjustment from estimated % change from baseline
+        """
         pass
 
-    def get_aggregate_prediction_intervals(self):
+    def get_all_conformalization_data_agg(self):
+        """
+        Returns conformalization data at the aggregate level
+        """
         pass
 
     def get_coefficients(self):

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -1,0 +1,267 @@
+import logging
+import math
+import warnings
+from collections import namedtuple
+
+import cvxpy
+import numpy as np
+from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
+
+from elexmodel.models import BaseElectionModel
+from elexmodel.handlers.data.Featurizer import Featurizer
+
+warnings.filterwarnings("error", category=UserWarning, module="cvxpy")
+
+PredictionIntervals = namedtuple("PredictionIntervals", ["lower", "upper", "conformalization"], defaults=(None,) * 3)
+
+LOG = logging.getLogger(__name__)
+
+
+class ConformalElectionModel(BaseElectionModel):
+    def __init__(self, model_settings={}):
+        self.qr = QuantileRegressionSolver(solver="ECOS")
+        self.features = model_settings.get("features", [])
+        self.fixed_effects = model_settings.get("fixed_effects", {})
+        self.lambda_ = model_settings.get("lambda_", 0)
+        self.features_to_coefficients = {}
+        self.featurizer = Featurizer(self.features, self.fixed_effects)
+        self.add_intercept = True
+        self.seed = 4191  # set arbitrarily
+
+    def fit_model(self, model, df_X, df_y, tau, weights, normalize_weights):
+        """
+        Fits the quantile regression for the model
+        """
+        X = df_X.values
+        y = df_y.values
+        weights = weights.values
+
+        # normalizing weights speed up solution by a lot. However, if the relative size
+        # of the smallest weight is too close to zero, it can lead to numerical instability
+        # where the solver either throws a warning for inaccurate solution or breaks entirely
+        # in that case, we catch the error and warning and re-run with normalize_weights false
+        try:
+            model.fit(
+                X,
+                y,
+                tau_value=tau,
+                weights=weights,
+                lambda_=self.lambda_,
+                fit_intercept=self.add_intercept,
+                normalize_weights=normalize_weights,
+            )
+        except (UserWarning, cvxpy.error.SolverError):
+            LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
+            model.fit(X, y, tau_value=tau, weights=weights, lambda_=self.lambda_, normalize_weights=False)
+
+    def get_unit_predictions(self, reporting_units, nonreporting_units, estimand):
+        """
+        Produces unit level predictions. Fits quantile regression to reporting data, applies
+        it to nonreporting data. The features are specified in model_settings.
+        """
+        # compute the means of both reporting_units and nonreporting_units for centering (part of featurizing)
+        # we want them both, since together they are the subunit population
+        self.featurizer.compute_means_for_centering(reporting_units, nonreporting_units)
+        # reporting_units_features and nonreporting_units_features should have the same
+        # features. Specifically also the same fixed effect columns.
+        reporting_units_features = self.featurizer.featurize_fitting_data(
+            reporting_units, add_intercept=self.add_intercept
+        )
+        nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
+
+        weights = reporting_units[f"last_election_results_{estimand}"]
+        reporting_units_residuals = reporting_units[f"residuals_{estimand}"]
+
+        self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
+        self.features_to_coefficients = dict(zip(self.featurizer.complete_features, self.qr.coefficients))
+
+        preds = self.qr.predict(nonreporting_units_features)
+
+        # multiply by total voters to get unnormalized residuals
+        preds = preds * nonreporting_units[f"last_election_results_{estimand}"]
+
+        # add in last election results to go from residual to number of votes in this election
+        # max with results so that predictions are always at least ars large as actual number of votes
+        preds = np.maximum(
+            preds + nonreporting_units[f"last_election_results_{estimand}"], nonreporting_units[f"results_{estimand}"]
+        )
+
+        # round since we don't need the artificial precision
+        return preds.round(decimals=0)
+
+    def _get_reporting_aggregate_votes(self, reporting_units, unexpected_units, aggregate, estimand):
+        """
+        Aggregate reporting votes by aggregate (ie. postal_code, county_fips etc.). This function
+        adds reporting data and reporting unexpected data by aggregate. Note that all unexpected units -
+        whether or not they are fully reporting - are included in this function.
+        """
+        reporting_units_known_votes = reporting_units.groupby(aggregate).sum().reset_index(drop=False)
+
+        # we cannot know the county classification of unexpected geographic units, so we can't add the votes back in
+        if "county_classification" in aggregate:
+            aggregate_votes = reporting_units_known_votes[aggregate + [f"results_{estimand}", "reporting"]]
+        else:
+            unexpected_units_known_votes = unexpected_units.groupby(aggregate).sum().reset_index(drop=False)
+
+            # outer join to ensure that if entire districts of county classes are unexpectedly present, we
+            # should still have them. Same reasoning to replace NA with zero
+            # NA means there was no such geographic unit, so they don't capture any votes
+            results_col = f"results_{estimand}"
+            reporting_col = "reporting"
+            aggregate_votes = (
+                reporting_units_known_votes.merge(
+                    unexpected_units_known_votes,
+                    how="outer",
+                    on=aggregate,
+                    suffixes=("_expected", "_unexpected"),
+                )
+                .fillna(
+                    {
+                        f"results_{estimand}_expected": 0,
+                        f"results_{estimand}_unexpected": 0,
+                        "reporting_expected": 0,
+                        "reporting_unexpected": 0,
+                    }
+                )
+                .assign(
+                    **{
+                        results_col: lambda x: x[f"results_{estimand}_expected"] + x[f"results_{estimand}_unexpected"],
+                        reporting_col: lambda x: x["reporting_expected"] + x["reporting_unexpected"],
+                    },
+                )[aggregate + [f"results_{estimand}", "reporting"]]
+            )
+
+        return aggregate_votes
+
+    def _get_nonreporting_aggregate_votes(self, nonreporting_units, aggregate):
+        """
+        Aggregate nonreporting votes by aggregate (ie. postal_code, county_fips etc.). Note that all unexpected
+        units - whether or not they are fully reporting - are handled in "_get_reporting_aggregate_votes" above
+        """
+        aggregate_nonreporting_units_known_votes = nonreporting_units.groupby(aggregate).sum().reset_index(drop=False)
+
+        return aggregate_nonreporting_units_known_votes
+
+    def get_aggregate_predictions(self, reporting_units, nonreporting_units, unexpected_units, aggregate, estimand):
+        """
+        Aggregate predictions and results by aggregate (ie. postal_code, county_fips etc.). Add results from reporting
+        and reporting unexpected units and then sum in the predictions from nonreporting units.
+        """
+        # these are subunits that are already counted
+        aggregate_votes = self._get_reporting_aggregate_votes(reporting_units, unexpected_units, aggregate, estimand)
+
+        # these are subunits that are not already counted
+        aggregate_preds = (
+            nonreporting_units.groupby(aggregate)
+            .sum()
+            .reset_index(drop=False)
+            .rename(
+                columns={
+                    f"pred_{estimand}": f"pred_only_{estimand}",
+                    f"results_{estimand}": f"results_only_{estimand}",
+                    "reporting": "reporting_only",
+                }
+            )
+        )
+        aggregate_data = (
+            aggregate_votes.merge(aggregate_preds, how="outer", on=aggregate)
+            .fillna(
+                {
+                    f"results_{estimand}": 0,
+                    f"pred_only_{estimand}": 0,
+                    f"results_only_{estimand}": 0,
+                    "reporting": 0,
+                    "reporting_only": 0,
+                }
+            )
+            .assign(
+                # don't need to sum results_only for predictions since those are superceded by pred_only
+                # preds can't be smaller than results, since we maxed between predictions and results in unit function.
+                **{
+                    f"pred_{estimand}": lambda x: x[f"results_{estimand}"] + x[f"pred_only_{estimand}"],
+                    f"results_{estimand}": lambda x: x[f"results_{estimand}"] + x[f"results_only_{estimand}"],
+                    "reporting": lambda x: x["reporting"] + x["reporting_only"],
+                },
+            )
+            .sort_values(aggregate)[aggregate + [f"pred_{estimand}", f"results_{estimand}", "reporting"]]
+            .reset_index(drop=True)
+        )
+
+        return aggregate_data
+
+    def get_unit_prediction_interval_bounds(self, reporting_units, nonreporting_units, conf_frac, alpha, estimand):
+        """
+        Get unadjusted unit prediction intervals. Splits reporting data into training data and conformalization data,
+        fits lower and upper quantile regression using training data and apply to both conformalization data
+        and nonreporting data to get conformalization lower/upper bounds and nonreporting lower/upper bounds.
+        Returns unadjusted bounds for nonreporting dat and conformalization data including bounds.
+        """
+        # split reporting data into training and conformalization data
+        # seed is set during initialization, to make sure we always get the same
+        # training/conformalization split for each alpha of one run
+        reporting_units_shuffled = reporting_units.sample(frac=1, random_state=self.seed).reset_index(drop=True)
+
+        upper_bound = (1 + alpha) / 2
+        lower_bound = (1 - alpha) / 2
+
+        train_rows = math.floor(reporting_units.shape[0] * conf_frac)
+        train_data = reporting_units_shuffled[:train_rows].reset_index(drop=True)
+
+        # specifying self.features extracts the correct columns and makes sure they are in the correct
+        # order. Necessary when fitting and predicting on the model.
+        # the fixed effects in train_data will be a subset of the fixed effect of reporting_units since all
+        # units from one fixed effect category might be in the conformalization data. Note that we are
+        # overwritting featurizer.expanded_fixed_effects by doing this (which is what we want), since we
+        # want the expanded_fixed_effects from train_data to be used by conformalization_data and nonreporting_data
+        # in this function.
+        train_data_features = self.featurizer.featurize_fitting_data(train_data, add_intercept=self.add_intercept)
+        train_data_residuals = train_data[f"residuals_{estimand}"]
+        train_data_weights = train_data[f"last_election_results_{estimand}"]
+
+        # fit lower and upper model to training data. ECOS solver is better than SCS.
+        lower_qr = QuantileRegressionSolver(solver="ECOS")
+        self.fit_model(lower_qr, train_data_features, train_data_residuals, lower_bound, train_data_weights, True)
+
+        upper_qr = QuantileRegressionSolver(solver="ECOS")
+        self.fit_model(upper_qr, train_data_features, train_data_residuals, upper_bound, train_data_weights, True)
+
+        # apply to conformalization data. Conformalization bounds will later tell us how much to adjust lower/upper
+        # bounds for nonreporting data.
+        conformalization_data = reporting_units_shuffled[train_rows:].reset_index(drop=True)
+        # conformalization features will be the same as the features in train_data
+        conformalization_data_features = self.featurizer.featurize_heldout_data(conformalization_data)
+
+        # we are interested in f(X) - r
+        # since later conformity scores care about deviation of bounds from residuals
+        conformalization_lower_bounds = (
+            lower_qr.predict(conformalization_data_features) - conformalization_data[f"residuals_{estimand}"].values
+        )
+        conformalization_upper_bounds = conformalization_data[f"residuals_{estimand}"].values - upper_qr.predict(
+            conformalization_data_features
+        )
+
+        # save conformalization bounds for later
+        conformalization_data["upper_bounds"] = conformalization_upper_bounds
+        conformalization_data["lower_bounds"] = conformalization_lower_bounds
+
+        # apply lower/upper models to nonreporting data
+        # now the features of the nonreporting_units will be the same as the train_data features
+        # they might differ slightly from the features used when fitting the median prediction
+        nonreporting_units_features = self.featurizer.featurize_heldout_data(nonreporting_units)
+        nonreporting_lower_bounds = lower_qr.predict(nonreporting_units_features)
+        nonreporting_upper_bounds = upper_qr.predict(nonreporting_units_features)
+
+        return PredictionIntervals(nonreporting_lower_bounds, nonreporting_upper_bounds, conformalization_data)
+
+    def get_unit_prediction_intervals(self):
+        pass
+
+    def get_aggregate_prediction_intervals(self):
+        pass
+
+    def get_coefficients(self):
+        """
+        Returns a dictionary of feature/fixed effect names to the quantile regression coefficients
+        These coefficients are for the point prediciton only, not for the lower or upper intervals models.
+        """
+        return self.features_to_coefficients

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -87,11 +87,20 @@ class GaussianElectionModel(ConformalElectionModel):
             lower.round(decimals=0), upper.round(decimals=0), prediction_intervals.conformalization
         )
 
-    # At the unit level, conformalization data is adjustment from estimated % change from baseline
     def get_all_conformalization_data_unit(self):
+        """
+        Returns the paramaters of the gaussian distribution used to adjust the intervals
+        and the conformalization data that was used to fit the distribution
+        In this (unit) case the parameters for one distribution is returned (ie. the distribution for all units)
+        """
         return self.gaussian_bounds_unit, self.conformalization_data_unit
 
     def get_all_conformalization_data_agg(self):
+        """
+        Returns the parameters of the gaussian distribution(s) used to adjust the intervals
+        and the conformalization data that were used to fit the distribution(s)
+        A distribution for each value of each aggregation is returned (ie. one per postal_code)
+        """
         return self.modeled_bounds_agg, self.conformalization_data_agg
 
     def get_aggregate_prediction_intervals(
@@ -101,14 +110,16 @@ class GaussianElectionModel(ConformalElectionModel):
         unexpected_units,
         aggregate,
         alpha,
-        conformalization_data,
+        unit_prediction_intervals,
         estimand,
     ):
         """
         Get aggregate prediction intervals. Adjust aggregate prediction intervals based on Gaussian models
         that are fit to conformalization data per group.
         """
-
+        # get conformalization data out of unit prediction intervals
+        conformalization_data = unit_prediction_intervals.conformalization
+        
         # get reporting votes by aggregate
         aggregate_votes = self._get_reporting_aggregate_votes(reporting_units, unexpected_units, aggregate, estimand)
 

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -3,13 +3,12 @@ import pandas as pd
 from scipy import stats
 
 from elexmodel.distributions.GaussianModel import GaussianModel
-from elexmodel.models.BaseElectionModel import BaseElectionModel, PredictionIntervals
+from elexmodel.models.ConformalElectionModel import ConformalElectionModel, PredictionIntervals
 
 
-class GaussianElectionModel(BaseElectionModel):
+class GaussianElectionModel(ConformalElectionModel):
     def __init__(self, model_settings={}):
         super().__init__(model_settings)
-        self.model_settings = model_settings
         self.alpha_to_nonreporting_lower_bounds = {}
         self.alpha_to_nonreporting_upper_bounds = {}
         self.modeled_bounds_agg = None

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -7,7 +7,7 @@ from elexmodel.models.ConformalElectionModel import ConformalElectionModel, Pred
 
 
 class GaussianElectionModel(ConformalElectionModel):
-    def __init__(self, model_settings={}):
+    def __init__(self, model_settings: dict):
         super().__init__(model_settings)
         self.alpha_to_nonreporting_lower_bounds = {}
         self.alpha_to_nonreporting_upper_bounds = {}
@@ -22,10 +22,10 @@ class GaussianElectionModel(ConformalElectionModel):
         """
         return 0.7
 
-    def get_minimum_reporting_units(self, alpha):
+    def get_minimum_reporting_units(self, alpha: float) -> float:
         return 10 * self._compute_conf_frac()
 
-    def get_unit_prediction_intervals(self, reporting_units, nonreporting_units, alpha, estimand):
+    def get_unit_prediction_intervals(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, alpha: float, estimand: str) -> PredictionIntervals:
         """
         Get unit prediction intervals in Gaussian case. Adjust unit prediction intervals based on Gaussian model
         that is fit to conformalization data.
@@ -87,7 +87,7 @@ class GaussianElectionModel(ConformalElectionModel):
             lower.round(decimals=0), upper.round(decimals=0), prediction_intervals.conformalization
         )
 
-    def get_all_conformalization_data_unit(self):
+    def get_all_conformalization_data_unit(self) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Returns the paramaters of the gaussian distribution used to adjust the intervals
         and the conformalization data that was used to fit the distribution
@@ -95,7 +95,7 @@ class GaussianElectionModel(ConformalElectionModel):
         """
         return self.gaussian_bounds_unit, self.conformalization_data_unit
 
-    def get_all_conformalization_data_agg(self):
+    def get_all_conformalization_data_agg(self) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Returns the parameters of the gaussian distribution(s) used to adjust the intervals
         and the conformalization data that were used to fit the distribution(s)
@@ -105,14 +105,14 @@ class GaussianElectionModel(ConformalElectionModel):
 
     def get_aggregate_prediction_intervals(
         self,
-        reporting_units,
-        nonreporting_units,
-        unexpected_units,
-        aggregate,
-        alpha,
-        unit_prediction_intervals,
-        estimand,
-    ):
+        reporting_units: pd.DataFrame,
+        nonreporting_units: pd.DataFrame,
+        unexpected_units: pd.DataFrame,
+        aggregate: list,
+        alpha: float,
+        unit_prediction_intervals: PredictionIntervals,
+        estimand: str,
+    ) -> PredictionIntervals:
         """
         Get aggregate prediction intervals. Adjust aggregate prediction intervals based on Gaussian models
         that are fit to conformalization data per group.

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -3,10 +3,10 @@ import math
 import numpy as np
 import pandas as pd
 
-from elexmodel.models.BaseElectionModel import BaseElectionModel, PredictionIntervals
+from elexmodel.models.ConformalElectionModel import ConformalElectionModel, PredictionIntervals
 
 
-class NonparametricElectionModel(BaseElectionModel):
+class NonparametricElectionModel(ConformalElectionModel):
     def __init__(self, model_settings={}):
         super().__init__(model_settings)
         self.robust = model_settings.get("robust", False)

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -103,11 +103,16 @@ class NonparametricElectionModel(ConformalElectionModel):
             lower.round(decimals=0), upper.round(decimals=0), prediction_intervals.conformalization
         )
 
-    # At the unit level, conformalization data is adjustment from estimated % change from baseline
     def get_all_conformalization_data_unit(self):
+        """
+        Returns the conformalization data for the unit adjustments
+        """
         return None, self.conformalization_data_unit
 
     def get_all_conformalization_data_agg(self):
+        """
+        Returns the conformalization data for the aggregate adjustments
+        """
         return None, self.conformalization_data_agg
 
     def get_aggregate_prediction_intervals(
@@ -117,7 +122,7 @@ class NonparametricElectionModel(ConformalElectionModel):
         unexpected_units,
         aggregate,
         alpha,
-        conformalization_data,
+        unit_prediction_intervals,
         estimand,
     ):
         """
@@ -125,6 +130,9 @@ class NonparametricElectionModel(ConformalElectionModel):
         Compute results from reporting data and nonreporting data and then sum in the lower and upper prediction
         intervals from nonreporting data.
         """
+        # get conformalization data out of unit prediction intervals
+        conformalization_data = unit_prediction_intervals.conformalization
+        
         # we're doing the same work as in get_aggregate_predictions here, can we just do this work once?
         aggregate_votes = self._get_reporting_aggregate_votes(reporting_units, unexpected_units, aggregate, estimand)
 

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -7,23 +7,23 @@ from elexmodel.models.ConformalElectionModel import ConformalElectionModel, Pred
 
 
 class NonparametricElectionModel(ConformalElectionModel):
-    def __init__(self, model_settings={}):
+    def __init__(self, model_settings: dict):
         super().__init__(model_settings)
         self.robust = model_settings.get("robust", False)
         self.conformalization_data_agg = None
         self.conformalization_data_unit = None
 
-    def _compute_conf_frac(self, n_reporting_units, alpha):
+    def _compute_conf_frac(self, n_reporting_units: int, alpha: float) -> float:
         """
         Returns fraction of reporting units to be part of conformalization set
         """
         # what happens if this is negative, which it is alpha 0.95 and n_reporting_units is 38
         return round(min(1 + (alpha + 1) / (n_reporting_units * (alpha - 1)), 0.9), 2)
 
-    def get_minimum_reporting_units(self, alpha):
+    def get_minimum_reporting_units(self, alpha: float) -> int:
         return math.ceil(-1 * (alpha + 1) / (alpha - 1))
 
-    def _compute_population_correction(self, conformalization_data, scores, correction_quantile, estimand):
+    def _compute_population_correction(self, conformalization_data: pd.DataFrame, scores: pd.Series, correction_quantile: float, estimand: str) -> float:
         """
         Compute population corrected conforalization correction.
         We care about larger units more than smaller units when computing aggregate prediction intervals.
@@ -44,7 +44,7 @@ class NonparametricElectionModel(ConformalElectionModel):
         population_correction = np.min(population_correction.scores)
         return population_correction
 
-    def get_unit_prediction_intervals(self, reporting_units, nonreporting_units, alpha, estimand):
+    def get_unit_prediction_intervals(self, reporting_units: pd.DataFrame, nonreporting_units: pd.DataFrame, alpha: float, estimand: str) -> PredictionIntervals:
         """
         Get unit prediction intervals for non-parametric model. Adjust nonreporting unit prediction intervals based
         on conformalization.
@@ -103,13 +103,13 @@ class NonparametricElectionModel(ConformalElectionModel):
             lower.round(decimals=0), upper.round(decimals=0), prediction_intervals.conformalization
         )
 
-    def get_all_conformalization_data_unit(self):
+    def get_all_conformalization_data_unit(self) -> tuple[None, pd.DataFrame]:
         """
         Returns the conformalization data for the unit adjustments
         """
         return None, self.conformalization_data_unit
 
-    def get_all_conformalization_data_agg(self):
+    def get_all_conformalization_data_agg(self) -> tuple[None, pd.DataFrame]:
         """
         Returns the conformalization data for the aggregate adjustments
         """
@@ -117,14 +117,14 @@ class NonparametricElectionModel(ConformalElectionModel):
 
     def get_aggregate_prediction_intervals(
         self,
-        reporting_units,
-        nonreporting_units,
-        unexpected_units,
-        aggregate,
-        alpha,
-        unit_prediction_intervals,
-        estimand,
-    ):
+        reporting_units: pd.DataFrame,
+        nonreporting_units: pd.DataFrame,
+        unexpected_units: pd.DataFrame,
+        aggregate: list,
+        alpha: float,
+        unit_prediction_intervals: PredictionIntervals,
+        estimand: str,
+    ) -> PredictionIntervals:
         """
         Get aggregate prediction intervals. In the non-parametric case prediction intervals just sum.
         Compute results from reporting data and nonreporting data and then sum in the lower and upper prediction

--- a/tests/models/test_base_election_model.py
+++ b/tests/models/test_base_election_model.py
@@ -7,43 +7,6 @@ from elexmodel.models import BaseElectionModel
 TOL = 1e-3
 
 
-def test_fit_model():
-    """
-    Test fitting the model.
-    """
-    model_settings = {}
-    model = BaseElectionModel.BaseElectionModel(model_settings)
-    qr = QuantileRegressionSolver(solver="ECOS")
-
-    df_X = pd.DataFrame({"a": [1, 1, 1, 1], "b": [1, 1, 1, 2]})
-
-    df_y = pd.DataFrame({"y": [3, 8, 9, 15]}).y
-    weights = pd.DataFrame({"weights": [1, 1, 1, 1]}).weights
-    model.fit_model(qr, df_X, df_y, 0.5, weights, True)
-
-    assert all(np.abs(qr.predict(df_X) - [8, 8, 8, 15]) <= TOL)
-    assert all(np.abs(qr.coefficients - [1, 7]) <= TOL)
-
-
-def test_get_unit_predictions():
-    model_settings = {"lambda_": 1, "features": ["b"]}
-    model = BaseElectionModel.BaseElectionModel(model_settings)
-    df_X = pd.DataFrame(
-        {
-            "residuals_a": [1, 2, 3, 4],
-            "total_voters_a": [4, 2, 9, 5],
-            "last_election_results_a": [5, 1, 4, 2],
-            "results_a": [0, 0, 0, 1],
-            "b": [2, 3, 4, 5],
-        }
-    )
-    model.get_unit_predictions(df_X, df_X, estimand="a")
-
-    "intercept" in model.features_to_coefficients
-    "b" in model.features_to_coefficients
-    model.features_to_coefficients["intercept"] > 0
-
-
 def test_aggregation_simple():
     """
     This test is a basic test for aggregating reporting votes. We have have two data frames, reporting votes and

--- a/tests/models/test_conformal_election_model.py
+++ b/tests/models/test_conformal_election_model.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+from elexsolver.QuantileRegressionSolver import QuantileRegressionSolver
+
+from elexmodel.models import ConformalElectionModel
+
+TOL = 1e-3
+
+
+def test_fit_model():
+    """
+    Test fitting the model.
+    """
+    model_settings = {}
+    model = ConformalElectionModel.ConformalElectionModel(model_settings)
+    qr = QuantileRegressionSolver(solver="ECOS")
+
+    df_X = pd.DataFrame({"a": [1, 1, 1, 1], "b": [1, 1, 1, 2]})
+
+    df_y = pd.DataFrame({"y": [3, 8, 9, 15]}).y
+    weights = pd.DataFrame({"weights": [1, 1, 1, 1]}).weights
+    model.fit_model(qr, df_X, df_y, 0.5, weights, True)
+
+    assert all(np.abs(qr.predict(df_X) - [8, 8, 8, 15]) <= TOL)
+    assert all(np.abs(qr.coefficients - [1, 7]) <= TOL)
+
+def test_get_unit_predictions():
+    model_settings = {"lambda_": 1, "features": ["b"]}
+    model = ConformalElectionModel.ConformalElectionModel(model_settings)
+    df_X = pd.DataFrame(
+        {
+            "residuals_a": [1, 2, 3, 4],
+            "total_voters_a": [4, 2, 9, 5],
+            "last_election_results_a": [5, 1, 4, 2],
+            "results_a": [0, 0, 0, 1],
+            "b": [2, 3, 4, 5],
+        }
+    )
+    model.get_unit_predictions(df_X, df_X, estimand="a")
+
+    "intercept" in model.features_to_coefficients
+    "b" in model.features_to_coefficients
+    model.features_to_coefficients["intercept"] > 0

--- a/tests/models/test_gaussian_election_model.py
+++ b/tests/models/test_gaussian_election_model.py
@@ -2,14 +2,16 @@ from elexmodel.models import GaussianElectionModel
 
 
 def test_compute_conf_frac():
-    model = GaussianElectionModel.GaussianElectionModel()
+    model_settings = {}
+    model = GaussianElectionModel.GaussianElectionModel(model_settings)
     conf_frac = model._compute_conf_frac()
 
     assert conf_frac == 0.7
 
 
 def test_get_minimum_reporting_units():
-    model = GaussianElectionModel.GaussianElectionModel()
+    model_settings = {}
+    model = GaussianElectionModel.GaussianElectionModel(model_settings)
     n_min = model.get_minimum_reporting_units(0.7)
 
     assert n_min == 7

--- a/tests/models/test_nonparametric_election_model.py
+++ b/tests/models/test_nonparametric_election_model.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from elexmodel.models import NonparametricElectionModel
+from elexmodel.models.ConformalElectionModel import PredictionIntervals
 
 TOL = 1e-5
 
@@ -38,7 +39,8 @@ def test_compute_conf_frac():
 
 
 def test_get_minimum_reporting_units():
-    model = NonparametricElectionModel.NonparametricElectionModel()
+    model_settings = {}
+    model = NonparametricElectionModel.NonparametricElectionModel(model_settings)
     n_min = model.get_minimum_reporting_units(0.7)
 
     assert n_min == 6
@@ -82,8 +84,9 @@ def test_aggregate_prediction_intervals_simple():
             f"upper_{alpha}_{estimand}": [9, 8, 7, 9, 5, 4],  # a: 17, c: 16, e: 9
         }
     )
-
-    intervals = model.get_aggregate_prediction_intervals(df1, df3, df2, ["c1"], alpha, None, estimand)
+    
+    prediction_intervals = PredictionIntervals([], [], [])
+    intervals = model.get_aggregate_prediction_intervals(df1, df3, df2, ["c1"], alpha, prediction_intervals, estimand)
 
     assert np.array_equal(np.asarray([12, 19, 8, 6, 3]), intervals.lower)
     assert np.array_equal(np.asarray([26, 19, 17, 6, 9]), intervals.upper)
@@ -113,10 +116,12 @@ def test_aggregate_prediction_intervals(va_governor_precinct_data):
     df3 = df[2000:].copy()
     df3["reporting"] = 1
 
-    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["postal_code"], alpha, None, estimand)
+    prediction_intervals = PredictionIntervals([], [], [])
+
+    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["postal_code"], alpha, prediction_intervals, estimand)
     assert 2535685.0 == intervals.lower[0]  # total based on summing csv
     assert 2535685.0 == intervals.upper[0]  # total based on summing csv
 
-    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["county_fips"], alpha, None, estimand)
+    intervals = model.get_aggregate_prediction_intervals(df1, df2, df3, ["county_fips"], alpha, prediction_intervals, estimand)
     assert 10664.0 == intervals.lower[0]  # first county based on summing csv
     assert 10664.0 == intervals.upper[0]  # first county based on summing csv

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -718,8 +718,8 @@ def test_conformalization_data(model_client, va_governor_county_data, va_config)
         save_output=[],
     )
 
-    conform_unit = model_client.model.get_all_conformalization_data_unit()
-    conform_agg = model_client.model.get_all_conformalization_data_agg()
+    conform_unit = model_client.all_conformalization_data_unit_dict
+    conform_agg = model_client.all_conformalization_data_agg_dict
 
     assert len(conform_unit) == 1
     assert len(conform_agg) == 1
@@ -746,8 +746,8 @@ def test_conformalization_data(model_client, va_governor_county_data, va_config)
         save_output=[],
     )
 
-    conform_unit = model_client.get_all_conformalization_data_unit()
-    conform_agg = model_client.get_all_conformalization_data_agg()
+    conform_unit = model_client.all_conformalization_data_unit_dict
+    conform_agg = model_client.all_conformalization_data_agg_dict
 
     assert len(conform_unit) == 1
     assert len(conform_agg) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -718,8 +718,8 @@ def test_conformalization_data(model_client, va_governor_county_data, va_config)
         save_output=[],
     )
 
-    conform_unit = model_client.get_all_conformalization_data_unit()
-    conform_agg = model_client.get_all_conformalization_data_agg()
+    conform_unit = model_client.model.get_all_conformalization_data_unit()
+    conform_agg = model_client.model.get_all_conformalization_data_agg()
 
     assert len(conform_unit) == 1
     assert len(conform_agg) == 1


### PR DESCRIPTION
## Description
In order to prepare for the Bootstrap model (which does not use conformalization), I had to change the inheritance structure of our models so far. We now have a `ConformalElectionModel` which inherits from the `BaseElectionModel` and the `GaussianElectionModel` and `NonparametricElectionModel` inherit from that. This means we can re-use the aggregation code from the `BaseElectionModel` in the upcoming bootstrap model without running into issues with a non-existent conformalization set. 

We now only deal with the conformalization data in the client if we are using a `ConformalElectionModel` rather than always, which is what we were doing previously.

I also added type hints and updated the unit tests correspondingly.

## Jira Ticket
[elex-2766 ](https://arcpublishing.atlassian.net/browse/ELEX-2766)

## Test Steps
Unit tests are updated, so `tox` works.

Also both old models work like normal:
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=dem --geographic_unit_type=county --pi_method=gaussian --percent_reporting=20 --model_parameters="{'lambda_': 1, 'beta': 4, 'winsorize': True}" --aggregates=postal_code --aggregates=county_classification --aggregates=unit
```
and 
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=dem --geographic_unit_type=county --pi_method=nonparametric --percent_reporting=20 --model_parameters="{'lambda_': 1, 'robust': True}"
```
