### PR TITLE
Elex 2771 new ols qr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("click<8.1", "elex-solver<2", "pandas<1.5.0", "boto3<2", "python-dotenv==0.19.2", "scipy==1.10.1")
+INSTALL_REQUIRES = ("click<8.1", "elex-solver<3", "pandas<1.5.0", "boto3<2", "python-dotenv==0.19.2", "scipy==1.10.1")
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -416,8 +416,8 @@ class HistoricalModelClient(ModelClient):
             historical=True,
             include_results_estimand=True,
         )
-
-        results_to_return = [f"results_{estimand}" for estimand in estimands]
+        # we always want to pass turnout so that we can generate results weights
+        results_to_return = list(set([f"results_{estimand}" for estimand in estimands] + ["results_turnout"]))
         geo_columns = set(["geographic_unit_fips", "postal_code"] + [a for a in self.aggregates if a != "unit"])
         preprocessed_data = preprocessed_data_handler.data[list(geo_columns) + results_to_return].copy()
         historical_current_data = preprocessed_data.merge(formatted_data, on=["postal_code", "geographic_unit_fips"])

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -52,7 +52,7 @@ class Estimandizer:
         # if we are in a historical election we are only reading preprocessed data to get
         # the historical election results of the currently reporting units.
         # so we don't care about the total voters or the baseline election.
-        
+
         data_df = self.add_weights(data_df, BASELINE_PREFIX)
 
         for estimand, pointer in estimand_baselines.items():

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -97,5 +97,7 @@ class Estimandizer:
 
 
 def party_vote_share_dem(data_df, col_prefix):
-    data_df[f"{col_prefix}party_vote_share_dem"] = np.nan_to_num(data_df[f"{col_prefix}dem"] /data_df[f"{col_prefix}turnout"])
+    data_df[f"{col_prefix}party_vote_share_dem"] = np.nan_to_num(
+        data_df[f"{col_prefix}dem"] / data_df[f"{col_prefix}turnout"]
+    )
     return data_df, []

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -13,6 +13,8 @@ class Estimandizer:
         columns_to_return = []
         turnout_col = f"{RESULTS_PREFIX}turnout"
 
+        data_df = self.add_weights(data_df, RESULTS_PREFIX)
+
         for estimand in estimands:
             results_col = f"{RESULTS_PREFIX}{estimand}"
             additional_columns_added = []
@@ -31,6 +33,7 @@ class Estimandizer:
                         # Hence, this is the only special case in which we'd want to add
                         # an empty results_ column.
                         data_df[results_col] = np.nan
+                        data_df[turnout_col] = np.nan
                     else:
                         # If this is not a historical run, then this is a live election
                         # so we are expecting that there will be actual results data
@@ -43,14 +46,14 @@ class Estimandizer:
         if turnout_col not in columns_to_return:
             columns_to_return.append(turnout_col)
 
-        data_df = self.add_weights(data_df, RESULTS_PREFIX)
-
         return data_df, columns_to_return
 
     def add_estimand_baselines(self, data_df, estimand_baselines, historical, include_results_estimand=False):
         # if we are in a historical election we are only reading preprocessed data to get
         # the historical election results of the currently reporting units.
         # so we don't care about the total voters or the baseline election.
+        
+        data_df = self.add_weights(data_df, BASELINE_PREFIX)
 
         for estimand, pointer in estimand_baselines.items():
             if pointer is None:
@@ -73,7 +76,6 @@ class Estimandizer:
             # we need to add the results from the historical election as well.
             data_df, ___ = self.add_estimand_results(data_df, estimand_baselines.keys(), historical)
 
-        data_df = self.add_weights(data_df, BASELINE_PREFIX)
         return data_df
 
     def add_weights(self, data_df, col_prefix):

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -97,11 +97,5 @@ class Estimandizer:
 
 
 def party_vote_share_dem(data_df, col_prefix):
-    numer = f"{col_prefix}dem"
-    denom = f"{col_prefix}turnout"
-
-    data_df[f"{col_prefix}party_vote_share_dem"] = data_df.apply(
-        lambda x: 0 if x[numer] == 0 or x[denom] == 0 else x[numer] / x[denom], axis=1
-    )
-
+    data_df[f"{col_prefix}party_vote_share_dem"] = np.nan_to_num(data_df[f"{col_prefix}dem"] /data_df[f"{col_prefix}turnout"])
     return data_df, []

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -81,7 +81,13 @@ class Estimandizer:
         return data_df
 
     def add_turnout_factor(self, data_df):
-        data_df["turnout_factor"] = np.nan_to_num(data_df.results_weights / data_df.baseline_weights)
+        # posinf and neginf are also set to zero because dividing by zero can lead to nan/posinf/neginf depending
+        # on the type of the numeric in the numpy array. Assume that if baseline_weights is zero then turnout
+        # would be incredibly low in this election too (ie. this is effectively an empty precinct) and so setting
+        # the turnout factor to zero is fine
+        data_df["turnout_factor"] = np.nan_to_num(
+            data_df.results_weights / data_df.baseline_weights, nan=0, posinf=0, neginf=0
+        )
         return data_df
 
 

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -36,14 +36,13 @@ class Estimandizer:
                         # so we are expecting that there will be actual results data
                         raise e
 
-
             columns_to_return.extend([results_col] + additional_columns_added)
 
         # always adding turnout since we will want to generate weights
         # but if turnout is the estimand, then we only want to add it once
         if turnout_col not in columns_to_return:
             columns_to_return.append(turnout_col)
-        
+
         data_df = self.add_weights(data_df, RESULTS_PREFIX)
 
         return data_df, columns_to_return

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -73,7 +73,7 @@ class Estimandizer:
             # Since this method is only called by the PreprocessedDataHandler, for historical runs,
             # we need to add the results from the historical election as well.
             data_df, ___ = self.add_estimand_results(data_df, estimand_baselines.keys(), historical)
-        
+
         data_df = self.add_weights(data_df, BASELINE_PREFIX)
 
         return data_df

--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -13,8 +13,6 @@ class Estimandizer:
         columns_to_return = []
         turnout_col = f"{RESULTS_PREFIX}turnout"
 
-        data_df = self.add_weights(data_df, RESULTS_PREFIX)
-
         for estimand in estimands:
             results_col = f"{RESULTS_PREFIX}{estimand}"
             additional_columns_added = []
@@ -46,14 +44,14 @@ class Estimandizer:
         if turnout_col not in columns_to_return:
             columns_to_return.append(turnout_col)
 
+        data_df = self.add_weights(data_df, RESULTS_PREFIX)
+
         return data_df, columns_to_return
 
     def add_estimand_baselines(self, data_df, estimand_baselines, historical, include_results_estimand=False):
         # if we are in a historical election we are only reading preprocessed data to get
         # the historical election results of the currently reporting units.
         # so we don't care about the total voters or the baseline election.
-
-        data_df = self.add_weights(data_df, BASELINE_PREFIX)
 
         for estimand, pointer in estimand_baselines.items():
             if pointer is None:
@@ -75,6 +73,8 @@ class Estimandizer:
             # Since this method is only called by the PreprocessedDataHandler, for historical runs,
             # we need to add the results from the historical election as well.
             data_df, ___ = self.add_estimand_results(data_df, estimand_baselines.keys(), historical)
+        
+        data_df = self.add_weights(data_df, BASELINE_PREFIX)
 
         return data_df
 

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -22,7 +22,6 @@ LOG = logging.getLogger(__name__)
 class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
     def __init__(self, model_settings: dict):
         super(ConformalElectionModel, self).__init__(model_settings)
-        self.qr = QuantileRegressionSolver(solver="ECOS")
         self.lambda_ = model_settings.get("lambda_", 0)
 
     @classmethod
@@ -56,11 +55,10 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
             model.fit(
                 X,
                 y,
-                tau_value=tau,
+                taus=tau,
                 weights=weights,
                 lambda_=self.lambda_,
                 fit_intercept=self.add_intercept,
-                normalize_weights=normalize_weights,
             )
         except (UserWarning, cvxpy.error.SolverError):
             LOG.warning("Warning: solution was inaccurate or solver broke. Re-running with normalize_weights=False.")
@@ -88,10 +86,11 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
             x_all[self.n_train : self.n_train + n_test]  # noqa: E203
         )
 
-        self.fit_model(self.qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
-        self.features_to_coefficients = dict(zip(featurizer.complete_features, self.qr.coefficients))
+        qr = QuantileRegressionSolver()
+        self.fit_model(qr, reporting_units_features, reporting_units_residuals, 0.5, weights, True)
+        self.features_to_coefficients = dict(zip(featurizer.complete_features, qr.coefficients))
 
-        preds = self.qr.predict(nonreporting_units_features)
+        preds = qr.predict(nonreporting_units_features.values).flatten()
 
         # multiply by total voters to get unnormalized residuals
         preds = preds * nonreporting_units[f"last_election_results_{estimand}"]
@@ -150,10 +149,10 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
         train_data_weights = train_data[f"last_election_results_{estimand}"]
 
         # fit lower and upper model to training data. ECOS solver is better than SCS.
-        lower_qr = QuantileRegressionSolver(solver="ECOS")
+        lower_qr = QuantileRegressionSolver()
         self.fit_model(lower_qr, train_data_features, train_data_residuals, lower_bound, train_data_weights, True)
 
-        upper_qr = QuantileRegressionSolver(solver="ECOS")
+        upper_qr = QuantileRegressionSolver()
         self.fit_model(upper_qr, train_data_features, train_data_residuals, upper_bound, train_data_weights, True)
 
         # apply to conformalization data. Conformalization bounds will later tell us how much to adjust lower/upper
@@ -169,10 +168,12 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
         # we are interested in f(X) - r
         # since later conformity scores care about deviation of bounds from residuals
         conformalization_lower_bounds = (
-            lower_qr.predict(conformalization_data_features) - conformalization_data[f"residuals_{estimand}"].values
+            lower_qr.predict(conformalization_data_features.values).flatten()
+            - conformalization_data[f"residuals_{estimand}"].values
         )
-        conformalization_upper_bounds = conformalization_data[f"residuals_{estimand}"].values - upper_qr.predict(
-            conformalization_data_features
+        conformalization_upper_bounds = (
+            conformalization_data[f"residuals_{estimand}"].values
+            - upper_qr.predict(conformalization_data_features.values).flatten()
         )
 
         # save conformalization bounds for later
@@ -185,8 +186,8 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
         # are the same accross train_data, conformalization_data and nonreporting_units
         nonreporting_units_features = interval_featurizer.generate_holdout_data(x_all[self.n_train :])  # noqa: E203
 
-        nonreporting_lower_bounds = lower_qr.predict(nonreporting_units_features)
-        nonreporting_upper_bounds = upper_qr.predict(nonreporting_units_features)
+        nonreporting_lower_bounds = lower_qr.predict(nonreporting_units_features.values).flatten()
+        nonreporting_upper_bounds = upper_qr.predict(nonreporting_units_features.values).flatten()
 
         return PredictionIntervals(nonreporting_lower_bounds, nonreporting_upper_bounds, conformalization_data)
 

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -157,7 +157,7 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
 
         # apply to conformalization data. Conformalization bounds will later tell us how much to adjust lower/upper
         # bounds for nonreporting data.
-        conformalization_data = reporting_units_shuffled[train_rows:]
+        conformalization_data = reporting_units_shuffled[train_rows:].reset_index(drop=True)
 
         # all_data starts with reporting_units_shuffled, so the rows between train_rows and n_train are the
         # conformalization set

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,43 +66,43 @@ def conformal_election_model():
     return ConformalElectionModel.ConformalElectionModel(model_settings)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def va_config(get_fixture):
     path = os.path.join("config", "2017-11-07_VA_G.json")
     return get_fixture(path, load=True, pandas=False)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def tx_primary_governor_config(get_fixture):
     path = os.path.join("config", "2018-03-06_TX_R.json")
     return get_fixture(path, load=True, pandas=False)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def va_governor_precinct_data(get_fixture):
     path = os.path.join("data", "2017-11-07_VA_G", "G", "data_precinct.csv")
     return get_fixture(path, load=False, pandas=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def va_governor_county_data(get_fixture):
     path = os.path.join("data", "2017-11-07_VA_G", "G", "data_county.csv")
     return get_fixture(path, load=False, pandas=True)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def va_assembly_county_data(get_fixture):
     path = os.path.join("data", "2017-11-07_VA_G", "Y", "data_county-district.csv")
     return get_fixture(path, load=False, pandas=True)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def va_assembly_precinct_data(get_fixture):
     path = os.path.join("data", "2017-11-07_VA_G", "Y", "data_precinct-district.csv")
     return get_fixture(path, load=False, pandas=True)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def az_assembly_precinct_data(get_fixture):
     path = os.path.join("data", "2020-08-04_AZ_R", "S", "data_precinct.csv")
     return get_fixture(path, load=False, pandas=True)

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -17,7 +17,12 @@ def test_load(va_governor_county_data):
     )
     current_data = live_data_handler.data
     preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office_id, geographic_unit_type, estimand_baselines=estimand_baselines, estimands=["turnout"], data=va_governor_county_data
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
     )
     preprocessed_data = preprocessed_data_handler.data
 
@@ -32,21 +37,37 @@ def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data)
     """
     Set the value for one estimand (dem) as na to test unreporting = "zero"
     """
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
+    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
-    live_data_handler = MockLiveDataHandler("2017-11-07_VA_G", "G", "county", estimands, data=va_governor_county_data)
+    live_data_handler = MockLiveDataHandler(
+        election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
+    )
     current_data = live_data_handler.data
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
+    )
+    preprocessed_data = preprocessed_data_handler.data
+
     combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0  # value with na result has been set to zero
     assert combined_data_handler.data["results_turnout"].iloc[0] != 0  # has not been set to zero
     assert (
         combined_data_handler.data["percent_expected_vote"].iloc[0] == 0
     )  # percent expected vote with na result has been set to zero
-    assert combined_data_handler.data.shape == (133, 35)  # didn't drop any
+    assert combined_data_handler.data.shape == (133, 36)  # didn't drop any
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -54,20 +75,36 @@ def test_zero_unreporting_missing_multiple_estimands_value(va_governor_county_da
     """
     Set the value for multiple estimands (dem, turnout) as na to test unreporting = "zero"
     """
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
+    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
-    live_data_handler = MockLiveDataHandler("2017-11-07_VA_G", "G", "county", estimands, data=va_governor_county_data)
+    live_data_handler = MockLiveDataHandler(
+        election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
+    )
     current_data = live_data_handler.data
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
     current_data.loc[0, "results_turnout"] = np.nan
 
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
+    )
+    preprocessed_data = preprocessed_data_handler.data
+
     combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["results_turnout"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 35)
+    assert combined_data_handler.data.shape == (133, 36)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
     assert combined_data_handler.data["results_turnout"].iloc[1] != 0  # didn't accidentally set other to zero
 
@@ -76,19 +113,35 @@ def test_zero_unreporting_missing_percent_expected_vote_value(va_governor_county
     """
     Set the value and percent reporting for one estimand (dem) as na to test unreporting = "zero"
     """
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
+    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
-    live_data_handler = MockLiveDataHandler("2017-11-07_VA_G", "G", "county", estimands, data=va_governor_county_data)
+    live_data_handler = MockLiveDataHandler(
+        election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
+    )
     current_data = live_data_handler.data
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "percent_expected_vote"] = np.nan
     current_data.loc[0, "results_dem"] = np.nan
 
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
+    )
+    preprocessed_data = preprocessed_data_handler.data
+
     combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 35)
+    assert combined_data_handler.data.shape == (133, 36)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -96,18 +149,34 @@ def test_zero_unreporting_random_percent_expected_vote_value(va_governor_county_
     """
     Set the value for one estimand (dem) as na to test unreporting = "zero"
     """
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
+    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
-    live_data_handler = MockLiveDataHandler("2017-11-07_VA_G", "G", "county", estimands, data=va_governor_county_data)
+    live_data_handler = MockLiveDataHandler(
+        election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
+    )
     current_data = live_data_handler.data
     current_data["percent_expected_vote"] = np.random.randint(1, 100, current_data.shape[0])
     current_data.loc[0, "results_dem"] = np.nan
 
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
+    )
+    preprocessed_data = preprocessed_data_handler.data
+
     combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0  # all values set to 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 35)
+    assert combined_data_handler.data.shape == (133, 36)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -115,16 +184,32 @@ def test_drop_unreporting_missing_single_estimand_value(va_governor_county_data)
     """
     Set the value for one estimand (dem) as na to test unreporting = "drop"
     """
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
+    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
-    live_data_handler = MockLiveDataHandler("2017-11-07_VA_G", "G", "county", estimands, data=va_governor_county_data)
+    live_data_handler = MockLiveDataHandler(
+        election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
+    )
     current_data = live_data_handler.data
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
-    combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id,
+        office_id,
+        geographic_unit_type,
+        estimand_baselines=estimand_baselines,
+        estimands=estimands,
+        data=va_governor_county_data,
     )
-    assert combined_data_handler.data.shape == (132, 35)  # dropped one
+    preprocessed_data = preprocessed_data_handler.data
+
+    combined_data_handler = CombinedDataHandler(
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="drop"
+    )
+    assert combined_data_handler.data.shape == (132, 36)  # dropped one
     assert combined_data_handler.data["results_dem"].iloc[0] != 0  # didn't accidentally set other to zero
 
 

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -7,16 +7,25 @@ from elexmodel.handlers.data.PreprocessedData import PreprocessedDataHandler
 
 
 def test_load(va_governor_county_data):
+    election_id = "2017-11-07_VA_G"
+    office_id = "G"
+    geographic_unit_type = "county"
     estimands = ["turnout"]
+    estimand_baselines = {"turnout": "turnout"}
     live_data_handler = MockLiveDataHandler(
-        "2017-11-07_VA_G", "G", "county", estimands=["turnout"], data=va_governor_county_data
+        election_id, office_id, geographic_unit_type, estimands=["turnout"], data=va_governor_county_data
     )
     current_data = live_data_handler.data
+    preprocessed_data_handler = PreprocessedDataHandler(
+        election_id, office_id, geographic_unit_type, estimand_baselines=estimand_baselines, estimands=["turnout"], data=va_governor_county_data
+    )
+    preprocessed_data = preprocessed_data_handler.data
 
     combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
+        preprocessed_data, current_data, estimands, "county", handle_unreporting="drop"
     )
-    assert combined_data_handler.data.shape == (133, 29)
+
+    assert combined_data_handler.data.shape == (133, 33)
 
 
 def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data):
@@ -37,7 +46,7 @@ def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data)
     assert (
         combined_data_handler.data["percent_expected_vote"].iloc[0] == 0
     )  # percent expected vote with na result has been set to zero
-    assert combined_data_handler.data.shape == (133, 31)  # didn't drop any
+    assert combined_data_handler.data.shape == (133, 35)  # didn't drop any
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -58,7 +67,7 @@ def test_zero_unreporting_missing_multiple_estimands_value(va_governor_county_da
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["results_turnout"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 31)
+    assert combined_data_handler.data.shape == (133, 35)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
     assert combined_data_handler.data["results_turnout"].iloc[1] != 0  # didn't accidentally set other to zero
 
@@ -79,7 +88,7 @@ def test_zero_unreporting_missing_percent_expected_vote_value(va_governor_county
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 31)
+    assert combined_data_handler.data.shape == (133, 35)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -98,7 +107,7 @@ def test_zero_unreporting_random_percent_expected_vote_value(va_governor_county_
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0  # all values set to 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 31)
+    assert combined_data_handler.data.shape == (133, 35)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -115,7 +124,7 @@ def test_drop_unreporting_missing_single_estimand_value(va_governor_county_data)
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
     )
-    assert combined_data_handler.data.shape == (132, 31)  # dropped one
+    assert combined_data_handler.data.shape == (132, 35)  # dropped one
     assert combined_data_handler.data["results_dem"].iloc[0] != 0  # didn't accidentally set other to zero
 
 

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -16,21 +16,13 @@ def test_load(va_governor_county_data):
         election_id, office_id, geographic_unit_type, estimands=["turnout"], data=va_governor_county_data
     )
     current_data = live_data_handler.data
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="drop"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
     )
 
-    assert combined_data_handler.data.shape == (133, 33)
+    assert combined_data_handler.data.shape == (133, 32)
 
 
 def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data):
@@ -49,25 +41,17 @@ def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data)
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0  # value with na result has been set to zero
     assert combined_data_handler.data["results_turnout"].iloc[0] != 0  # has not been set to zero
     assert (
         combined_data_handler.data["percent_expected_vote"].iloc[0] == 0
     )  # percent expected vote with na result has been set to zero
-    assert combined_data_handler.data.shape == (133, 36)  # didn't drop any
+    assert combined_data_handler.data.shape == (133, 34)  # didn't drop any
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -88,23 +72,15 @@ def test_zero_unreporting_missing_multiple_estimands_value(va_governor_county_da
     current_data.loc[0, "results_dem"] = np.nan
     current_data.loc[0, "results_turnout"] = np.nan
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["results_turnout"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 36)
+    assert combined_data_handler.data.shape == (133, 34)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
     assert combined_data_handler.data["results_turnout"].iloc[1] != 0  # didn't accidentally set other to zero
 
@@ -126,22 +102,14 @@ def test_zero_unreporting_missing_percent_expected_vote_value(va_governor_county
     current_data.loc[0, "percent_expected_vote"] = np.nan
     current_data.loc[0, "results_dem"] = np.nan
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 36)
+    assert combined_data_handler.data.shape == (133, 34)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -161,22 +129,14 @@ def test_zero_unreporting_random_percent_expected_vote_value(va_governor_county_
     current_data["percent_expected_vote"] = np.random.randint(1, 100, current_data.shape[0])
     current_data.loc[0, "results_dem"] = np.nan
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="zero"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
     )
     assert combined_data_handler.data["results_dem"].iloc[0] == 0.0  # all values set to 0.0
     assert combined_data_handler.data["percent_expected_vote"].iloc[0] == 0.0
-    assert combined_data_handler.data.shape == (133, 36)
+    assert combined_data_handler.data.shape == (133, 34)
     assert combined_data_handler.data["results_dem"].iloc[1] != 0  # didn't accidentally set other to zero
 
 
@@ -196,20 +156,12 @@ def test_drop_unreporting_missing_single_estimand_value(va_governor_county_data)
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id,
-        office_id,
-        geographic_unit_type,
-        estimand_baselines=estimand_baselines,
-        estimands=estimands,
-        data=va_governor_county_data,
-    )
-    preprocessed_data = preprocessed_data_handler.data
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data, current_data, estimands, "county", handle_unreporting="drop"
+        va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
     )
-    assert combined_data_handler.data.shape == (132, 36)  # dropped one
+    assert combined_data_handler.data.shape == (132, 34)  # dropped one
     assert combined_data_handler.data["results_dem"].iloc[0] != 0  # didn't accidentally set other to zero
 
 
@@ -224,13 +176,13 @@ def test_get_reporting_data(va_governor_county_data):
         election_id, office, geographic_unit_type, estimands, data=va_governor_county_data
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office, geographic_unit_type, estimands, estimand_baseline, data=va_governor_county_data
-    )
+
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
     # no fixed effects
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
+        va_governor_county_data, current_data, estimands, geographic_unit_type
     )
     observed_data = combined_data_handler.get_reporting_units(100)
     assert observed_data.shape[0] == 20
@@ -249,12 +201,12 @@ def test_get_reporting_data_dropping_with_turnout_factor(va_governor_county_data
         election_id, office, geographic_unit_type, estimands, data=va_governor_county_data
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office, geographic_unit_type, estimands, estimand_baseline, data=va_governor_county_data
-    )
+    
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
+        va_governor_county_data, current_data, estimands, geographic_unit_type
     )
 
     turnout_factor_lower = 0.95
@@ -290,12 +242,12 @@ def test_get_nonreporting_adding_with_turnout_factor(va_governor_county_data):
     )
     n = 20
     current_data = live_data_handler.get_n_fully_reported(n=n)
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office, geographic_unit_type, estimands, estimand_baseline, data=va_governor_county_data
-    )
+    
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
+        va_governor_county_data, current_data, estimands, geographic_unit_type
     )
 
     turnout_factor_lower = 0.95
@@ -339,12 +291,12 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
         unexpected_units=unexpected_units,
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office, geographic_unit_type, estimands, estimand_baseline, data=va_assembly_county_data
-    )
+    
+    va_assembly_county_data['baseline_weights'] = va_assembly_county_data.baseline_turnout
+    va_assembly_county_data['last_election_results_turnout'] = va_assembly_county_data.baseline_turnout + 1
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
+        va_assembly_county_data, current_data, estimands, geographic_unit_type
     )
     unexpected_data = combined_data_handler.get_unexpected_units(100, ["county_fips", "district"])
     assert unexpected_data.shape[0] == unexpected_units
@@ -377,12 +329,11 @@ def test_get_unexpected_units_county(va_governor_county_data):
     extra_row["percent_expected_vote"] = 50
     current_data = pd.concat([current_data, extra_row])
 
-    preprocessed_data_handler = PreprocessedDataHandler(
-        election_id, office, geographic_unit_type, estimands, estimand_baseline, data=va_governor_county_data
-    )
+    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
     combined_data_handler = CombinedDataHandler(
-        preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
+        va_governor_county_data, current_data, estimands, geographic_unit_type
     )
     unexpected_data = combined_data_handler.get_unexpected_units(100, ["county_fips"])
     assert unexpected_data.shape[0] == reporting_unexpected_units + 1

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 from elexmodel.handlers.data.CombinedData import CombinedDataHandler
 from elexmodel.handlers.data.LiveData import MockLiveDataHandler
-from elexmodel.handlers.data.PreprocessedData import PreprocessedDataHandler
 
 
 def test_load(va_governor_county_data):
@@ -11,12 +10,11 @@ def test_load(va_governor_county_data):
     office_id = "G"
     geographic_unit_type = "county"
     estimands = ["turnout"]
-    estimand_baselines = {"turnout": "turnout"}
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands=["turnout"], data=va_governor_county_data
     )
     current_data = live_data_handler.data
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
@@ -32,7 +30,6 @@ def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data)
     election_id = "2017-11-07_VA_G"
     office_id = "G"
     geographic_unit_type = "county"
-    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
@@ -41,7 +38,7 @@ def test_zero_unreporting_missing_single_estimand_value(va_governor_county_data)
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
@@ -62,7 +59,6 @@ def test_zero_unreporting_missing_multiple_estimands_value(va_governor_county_da
     election_id = "2017-11-07_VA_G"
     office_id = "G"
     geographic_unit_type = "county"
-    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
@@ -72,7 +68,7 @@ def test_zero_unreporting_missing_multiple_estimands_value(va_governor_county_da
     current_data.loc[0, "results_dem"] = np.nan
     current_data.loc[0, "results_turnout"] = np.nan
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
@@ -92,7 +88,6 @@ def test_zero_unreporting_missing_percent_expected_vote_value(va_governor_county
     election_id = "2017-11-07_VA_G"
     office_id = "G"
     geographic_unit_type = "county"
-    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
@@ -102,7 +97,7 @@ def test_zero_unreporting_missing_percent_expected_vote_value(va_governor_county
     current_data.loc[0, "percent_expected_vote"] = np.nan
     current_data.loc[0, "results_dem"] = np.nan
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
@@ -120,7 +115,6 @@ def test_zero_unreporting_random_percent_expected_vote_value(va_governor_county_
     election_id = "2017-11-07_VA_G"
     office_id = "G"
     geographic_unit_type = "county"
-    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
@@ -129,7 +123,7 @@ def test_zero_unreporting_random_percent_expected_vote_value(va_governor_county_
     current_data["percent_expected_vote"] = np.random.randint(1, 100, current_data.shape[0])
     current_data.loc[0, "results_dem"] = np.nan
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="zero"
@@ -147,7 +141,6 @@ def test_drop_unreporting_missing_single_estimand_value(va_governor_county_data)
     election_id = "2017-11-07_VA_G"
     office_id = "G"
     geographic_unit_type = "county"
-    estimand_baselines = {"turnout": "turnout", "dem": "dem"}
     estimands = ["turnout", "dem"]
     live_data_handler = MockLiveDataHandler(
         election_id, office_id, geographic_unit_type, estimands, data=va_governor_county_data
@@ -156,7 +149,7 @@ def test_drop_unreporting_missing_single_estimand_value(va_governor_county_data)
     current_data["percent_expected_vote"] = 100
     current_data.loc[0, "results_dem"] = np.nan
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
 
     combined_data_handler = CombinedDataHandler(
         va_governor_county_data, current_data, estimands, "county", handle_unreporting="drop"
@@ -170,20 +163,17 @@ def test_get_reporting_data(va_governor_county_data):
     office = "G"
     geographic_unit_type = "county"
     estimands = ["turnout"]
-    estimand_baseline = {"turnout": "turnout"}
 
     live_data_handler = MockLiveDataHandler(
         election_id, office, geographic_unit_type, estimands, data=va_governor_county_data
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
-    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["last_election_results_turnout"] = va_governor_county_data.baseline_turnout + 1
 
     # no fixed effects
-    combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, geographic_unit_type
-    )
+    combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     observed_data = combined_data_handler.get_reporting_units(100)
     assert observed_data.shape[0] == 20
     assert observed_data.reporting.iloc[0] == 1
@@ -195,19 +185,16 @@ def test_get_reporting_data_dropping_with_turnout_factor(va_governor_county_data
     office = "G"
     geographic_unit_type = "county"
     estimands = ["turnout"]
-    estimand_baseline = {"turnout": "turnout"}
 
     live_data_handler = MockLiveDataHandler(
         election_id, office, geographic_unit_type, estimands, data=va_governor_county_data
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
-    
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
-    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
-    combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, geographic_unit_type
-    )
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["last_election_results_turnout"] = va_governor_county_data.baseline_turnout + 1
+
+    combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
 
     turnout_factor_lower = 0.95
     turnout_factor_upper = 1.2
@@ -235,20 +222,17 @@ def test_get_nonreporting_adding_with_turnout_factor(va_governor_county_data):
     office = "G"
     geographic_unit_type = "county"
     estimands = ["turnout"]
-    estimand_baseline = {"turnout": "turnout"}
 
     live_data_handler = MockLiveDataHandler(
         election_id, office, geographic_unit_type, estimands, data=va_governor_county_data
     )
     n = 20
     current_data = live_data_handler.get_n_fully_reported(n=n)
-    
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
-    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
 
-    combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, geographic_unit_type
-    )
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["last_election_results_turnout"] = va_governor_county_data.baseline_turnout + 1
+
+    combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
 
     turnout_factor_lower = 0.95
     turnout_factor_upper = 1.2
@@ -280,7 +264,6 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
     geographic_unit_type = "county-district"
     estimands = ["turnout"]
     unexpected_units = 5
-    estimand_baseline = {"turnout": "turnout"}
 
     live_data_handler = MockLiveDataHandler(
         election_id,
@@ -291,13 +274,11 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
         unexpected_units=unexpected_units,
     )
     current_data = live_data_handler.get_n_fully_reported(n=20)
-    
-    va_assembly_county_data['baseline_weights'] = va_assembly_county_data.baseline_turnout
-    va_assembly_county_data['last_election_results_turnout'] = va_assembly_county_data.baseline_turnout + 1
 
-    combined_data_handler = CombinedDataHandler(
-        va_assembly_county_data, current_data, estimands, geographic_unit_type
-    )
+    va_assembly_county_data["baseline_weights"] = va_assembly_county_data.baseline_turnout
+    va_assembly_county_data["last_election_results_turnout"] = va_assembly_county_data.baseline_turnout + 1
+
+    combined_data_handler = CombinedDataHandler(va_assembly_county_data, current_data, estimands, geographic_unit_type)
     unexpected_data = combined_data_handler.get_unexpected_units(100, ["county_fips", "district"])
     assert unexpected_data.shape[0] == unexpected_units
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0
@@ -312,7 +293,6 @@ def test_get_unexpected_units_county(va_governor_county_data):
     geographic_unit_type = "county"
     estimands = ["turnout"]
     reporting_unexpected_units = 5
-    estimand_baseline = {"turnout": "turnout"}
 
     live_data_handler = MockLiveDataHandler(
         election_id,
@@ -329,12 +309,10 @@ def test_get_unexpected_units_county(va_governor_county_data):
     extra_row["percent_expected_vote"] = 50
     current_data = pd.concat([current_data, extra_row])
 
-    va_governor_county_data['baseline_weights'] = va_governor_county_data.baseline_turnout
-    va_governor_county_data['last_election_results_turnout'] = va_governor_county_data.baseline_turnout + 1
+    va_governor_county_data["baseline_weights"] = va_governor_county_data.baseline_turnout
+    va_governor_county_data["last_election_results_turnout"] = va_governor_county_data.baseline_turnout + 1
 
-    combined_data_handler = CombinedDataHandler(
-        va_governor_county_data, current_data, estimands, geographic_unit_type
-    )
+    combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     unexpected_data = combined_data_handler.get_unexpected_units(100, ["county_fips"])
     assert unexpected_data.shape[0] == reporting_unexpected_units + 1
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0

--- a/tests/handlers/test_estimandizer.py
+++ b/tests/handlers/test_estimandizer.py
@@ -1,3 +1,5 @@
+import pytest
+
 from elexmodel.handlers.data.Estimandizer import Estimandizer
 
 
@@ -13,6 +15,7 @@ def test_add_estimand_results_not_historical(va_governor_county_data):
     (output_df, result_columns) = estimandizer.add_estimand_results(va_data_copy, estimands, False)
 
     assert "results_party_vote_share_dem" in output_df.columns
+    assert "results_weights" in output_df.columns
     assert result_columns == ["results_party_vote_share_dem", "results_turnout"]
 
 
@@ -27,6 +30,7 @@ def test_add_estimand_results_historical(va_governor_county_data):
     (output_df, result_columns) = estimandizer.add_estimand_results(va_data_copy, estimands, True)
 
     assert "results_party_vote_share_dem" in output_df.columns
+    assert "results_weights" in output_df.columns
     assert result_columns == ["results_party_vote_share_dem", "results_turnout"]
 
 
@@ -34,6 +38,7 @@ def test_add_estimand_baselines_not_historical(va_governor_county_data):
     estimand_baselines = {"turnout": "turnout", "party_vote_share_dem": "party_vote_share_dem"}
     estimandizer = Estimandizer()
     output_df = estimandizer.add_estimand_baselines(va_governor_county_data.copy(), estimand_baselines, False)
+    assert "baseline_weights" in output_df.columns
     assert "baseline_party_vote_share_dem" in output_df.columns
     assert "last_election_results_party_vote_share_dem" in output_df.columns
 
@@ -45,5 +50,26 @@ def test_add_estimand_baselines_historical(va_governor_county_data):
         va_governor_county_data.copy(), estimand_baselines, True, include_results_estimand=True
     )
     assert "baseline_party_vote_share_dem" in output_df.columns
+    assert "baseline_weights" in output_df.columns
     assert "results_party_vote_share_dem" in output_df.columns
     assert "last_election_results_party_vote_share_dem" not in output_df.columns
+
+
+def test_add_turnout_factor(va_governor_county_data):
+    estimands = ["party_vote_share_dem", "turnout"]
+    estimand_baselines = {"turnout": "turnout", "party_vote_share_dem": "party_vote_share_dem"}
+    estimandizer = Estimandizer()
+    output_df = estimandizer.add_estimand_baselines(
+        va_governor_county_data.copy(), estimand_baselines, False, include_results_estimand=False
+    )
+    output_df, __ = estimandizer.add_estimand_results(output_df, estimands, False)
+
+    # check that nan turns into 0
+    output_df.loc[0, "baseline_weights"] = 0.0
+    import pdb
+
+    pdb.set_trace()
+    output_df = estimandizer.add_turnout_factor(output_df)
+
+    assert "turnout_factor" in output_df.columns
+    assert 0 == pytest.approx(output_df.loc[0, "turnout_factor"])

--- a/tests/handlers/test_estimandizer.py
+++ b/tests/handlers/test_estimandizer.py
@@ -66,9 +66,6 @@ def test_add_turnout_factor(va_governor_county_data):
 
     # check that nan turns into 0
     output_df.loc[0, "baseline_weights"] = 0.0
-    import pdb
-
-    pdb.set_trace()
     output_df = estimandizer.add_turnout_factor(output_df)
 
     assert "turnout_factor" in output_df.columns

--- a/tests/handlers/test_estimandizer.py
+++ b/tests/handlers/test_estimandizer.py
@@ -13,7 +13,7 @@ def test_add_estimand_results_not_historical(va_governor_county_data):
     (output_df, result_columns) = estimandizer.add_estimand_results(va_data_copy, estimands, False)
 
     assert "results_party_vote_share_dem" in output_df.columns
-    assert result_columns == ["results_party_vote_share_dem"]
+    assert result_columns == ["results_party_vote_share_dem", "results_turnout"]
 
 
 def test_add_estimand_results_historical(va_governor_county_data):
@@ -27,7 +27,7 @@ def test_add_estimand_results_historical(va_governor_county_data):
     (output_df, result_columns) = estimandizer.add_estimand_results(va_data_copy, estimands, True)
 
     assert "results_party_vote_share_dem" in output_df.columns
-    assert result_columns == ["results_party_vote_share_dem"]
+    assert result_columns == ["results_party_vote_share_dem", "results_turnout"]
 
 
 def test_add_estimand_baselines_not_historical(va_governor_county_data):

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -360,8 +360,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     reporting_data_features = featurizer.filter_to_active_features(x_all[:n_train])
     nonreporting_data_features = featurizer.generate_holdout_data(x_all[n_train:])
 
-    assert combined_data_handler.data.shape == (133, 32)
-
+    assert combined_data_handler.data.shape == (133, 35)
     n_expected_columns = 6  # (6 - 1) fixed effects + 1 intercept
     assert reporting_data_features.shape == (133, n_expected_columns)
     assert nonreporting_data_features.shape == (0, n_expected_columns)
@@ -394,7 +393,7 @@ def test_generate_fixed_effects(va_governor_county_data):
     reporting_data_features = featurizer.filter_to_active_features(x_all[:n_train])
     nonreporting_data_features = featurizer.generate_holdout_data(x_all[n_train:])
 
-    assert combined_data_handler.data.shape == (133, 32)
+    assert combined_data_handler.data.shape == (133, 35)
 
     n_expected_columns = 138  # (6 - 1) + (133 - 1) fixed effects + 1 intercept
     assert reporting_data_features.shape == (133, n_expected_columns)
@@ -451,7 +450,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
     reporting_data_features = featurizer.filter_to_active_features(x_all[:n_train])
     nonreporting_data_features = featurizer.generate_holdout_data(x_all[n_train:])
 
-    assert combined_data_handler.data.shape == (133, 32)
+    assert combined_data_handler.data.shape == (133, 35)
 
     n_expected_columns = (n - 1) + 1  # minus 1 for dropped fixed effect, plus 1 for intercept
     assert reporting_data_features.shape == (n, n_expected_columns)
@@ -519,7 +518,7 @@ def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
     reporting_data_features = featurizer.filter_to_active_features(x_all[:n_train])
     nonreporting_data_features = featurizer.generate_holdout_data(x_all[n_train:])
 
-    assert combined_data_handler.data.shape == (2360, 32)
+    assert combined_data_handler.data.shape == (2360, 35)
 
     n_expected_columns = 7  # when n = 100 we get to county 51013 (minus dropped fixed effect, plus intercept)
     assert reporting_data_features.shape == (n_train, n_expected_columns)  # use n_train since dropping columns

--- a/tests/models/test_nonparametric_election_model.py
+++ b/tests/models/test_nonparametric_election_model.py
@@ -408,7 +408,7 @@ def test_fit_model():
     """
     model_settings = {}
     model = NonparametricElectionModel.NonparametricElectionModel(model_settings)
-    qr = QuantileRegressionSolver(solver="ECOS")
+    qr = QuantileRegressionSolver()
 
     df_X = pd.DataFrame({"a": [1, 1, 1, 1], "b": [1, 1, 1, 2]})
 
@@ -416,8 +416,8 @@ def test_fit_model():
     weights = pd.DataFrame({"weights": [1, 1, 1, 1]}).weights
     model.fit_model(qr, df_X, df_y, 0.5, weights, True)
 
-    assert all(np.abs(qr.predict(df_X) - [8, 8, 8, 15]) <= TOL)
-    assert all(np.abs(qr.coefficients - [1, 7]) <= TOL)
+    np.testing.assert_allclose(qr.predict(df_X), [[8, 8, 8, 15]], rtol=TOL)
+    np.testing.assert_allclose(qr.coefficients, [[1, 7]], rtol=TOL)
 
 
 def test_get_unit_predictions():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -785,7 +785,6 @@ def test_estimandizer_input(model_client, va_governor_county_data, va_config):
 
     preprocessed_data = va_governor_county_data.copy()
     preprocessed_data["last_election_results_turnout"] = preprocessed_data["baseline_turnout"].copy() + 1
-
     try:
         model_client.get_estimates(
             data,


### PR DESCRIPTION
## Description
This PR moves over parts of the changes we are making for the [bootstrap election model PR](https://github.com/washingtonpost/elex-live-model/pull/76) in order to make reviewing that one easier. It make the changes necessary to the old `ConformalElectionModel` to work with the updates made to elex-solver [in this PR](https://github.com/washingtonpost/elex-solver/pull/11) and it makes small tweaks to the estimandizer to prepare it for multiple estimands being generated at once. It also updates unit tests accordingly.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-2771

## Test Steps
`tox`

also 
```
elexmodel 2020-11-03_USA_G --office_id=P --estimands=dem --geographic_unit_type=county --pi_method=nonparametric --percent_reporting=30 --aggregates=postal_code --historical
```
