### PR TITLE
ELEX-3055: Update all `elexmodel` requirements in an attempt to silence numpy/pandas warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,14 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("click~=8.1", "elex-solver>=2.0.1", "pandas~=2.1", "boto3~=1.28", "python-dotenv~=1.0", "scipy~=1.11")
+INSTALL_REQUIRES = (
+    "click~=8.1",
+    "elex-solver>=2.0.1",
+    "pandas~=2.1",
+    "boto3~=1.28",
+    "python-dotenv~=1.0",
+    "scipy~=1.11",
+)
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("click<8.1", "elex-solver<3", "pandas<1.5.0", "boto3<2", "python-dotenv==0.19.2", "scipy==1.10.1")
+INSTALL_REQUIRES = ("click~=8.1", "elex-solver", "pandas~=2.1", "boto3~=1.28", "python-dotenv~=1.0", "scipy~=1.11")
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ("click~=8.1", "elex-solver", "pandas~=2.1", "boto3~=1.28", "python-dotenv~=1.0", "scipy~=1.11")
+INSTALL_REQUIRES = ("click~=8.1", "elex-solver>=2.0.1", "pandas~=2.1", "boto3~=1.28", "python-dotenv~=1.0", "scipy~=1.11")
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -177,6 +177,7 @@ class Featurizer:
 
             # set the values for active fixed effect in rows that have inactive fixed effect to be 1 / (n + 1)
             # rows that have an inactive fixed effect value need to receive the treat of the average fixed effects
+            df[fe_active_fixed_effects] = df[fe_active_fixed_effects].astype("float64")
             df.loc[rows_w_inactive_fixed_effects, fe_active_fixed_effects] = 1 / (len(fe_active_fixed_effects) + 1)
             # This is correct because even rows with active fixed effects have an interept columns, so the coefficient
             # of the fixed effect value column is actually the *difference* between the dropped column

--- a/src/elexmodel/logging.py
+++ b/src/elexmodel/logging.py
@@ -32,3 +32,4 @@ def initialize_logging(logging_config=None):
         LOGGING_CONFIG["loggers"]["elexmodel"]["level"] = app_log_level
         logging_config = LOGGING_CONFIG
     logging.config.dictConfig(logging_config)
+    logging.captureWarnings(True)

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -398,7 +398,11 @@ def test_sample_test_epsilon(bootstrap_election_model):
     aggregate_indicator_test = np.asarray(
         [[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
     )
-    epsilon_hat = bootstrap_election_model._estimate_epsilon(residuals, aggregate_indicator_train)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # Note: this line along with this data performs a division by zero, which numpy is right to warn us about.
+        # We have currently disabled the warning here, and the Jira ticket to resolve this division-by-zero
+        # circumstance is here: https://arcpublishing.atlassian.net/browse/ELEX-3431
+        epsilon_hat = bootstrap_election_model._estimate_epsilon(residuals, aggregate_indicator_train)
 
     epsilon_y, epsilon_z = bootstrap_election_model._sample_test_epsilon(
         residuals, residuals, epsilon_hat, epsilon_hat, aggregate_indicator_train, aggregate_indicator_test
@@ -432,7 +436,12 @@ def test_sample_test_errors(bootstrap_election_model):
     aggregate_indicator_test = np.asarray(
         [[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
     )
-    epsilon_hat = bootstrap_election_model._estimate_epsilon(residuals, aggregate_indicator_train)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # Note: this line along with this data performs a division by zero, which numpy is right to warn us about.
+        # We have currently disabled the warning here, and the Jira ticket to resolve this division-by-zero
+        # circumstance is here: https://arcpublishing.atlassian.net/browse/ELEX-3431
+        epsilon_hat = bootstrap_election_model._estimate_epsilon(residuals, aggregate_indicator_train)
     delta_hat = bootstrap_election_model._estimate_delta(residuals, epsilon_hat, aggregate_indicator_train)
 
     x_train, x_test = None, None


### PR DESCRIPTION
## Description

Hello!  The changes in this PR:
* upgrade all required packages to their latest versions;
* silence warnings revealed by our unit tests;
* ensure that all warnings generated in production are being logged (at the `WARN` level) 🎉 

## Jira Ticket

ELEX-3055

## Test Steps

~~Testing this is a bit complicated until [this PR on `elex-solver`](https://github.com/washingtonpost/elex-solver/pull/14) is merged and a new `elex-solver` package exists, but here's what you can do locally:~~

You can now test using `tox` and/or various `elexmodel` commands etc. 😄 🎉 