### PR TITLE
no longer throws an error

### DIFF
--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -30,7 +30,7 @@ class PythonLiteralOption(click.Option):
 @click.option("--office_id", "office_id")
 @click.option("--fixed_effects", "fixed_effects", default={})
 @click.option("--features", default=[], multiple=True)
-@click.option("--aggregates", default=["postal_code", "unit"], multiple=True)
+@click.option("--aggregates", multiple=True)
 @click.option(
     "--pi_method",
     "pi_method",
@@ -90,6 +90,8 @@ def cli(
 
     kwargs["features"] = list(kwargs["features"])
     kwargs["aggregates"] = list(kwargs["aggregates"])
+    if len(kwargs["aggregates"]) == 0:
+        del kwargs["aggregates"]
     try:
         kwargs["fixed_effects"] = json.loads(kwargs["fixed_effects"])
     except json.decoder.JSONDecodeError:


### PR DESCRIPTION
## Description
I realized that this was throwing an error:
```
elexmodel 2019-11-05_VA_G --office_id=Y --estimands=dem --geographic_unit_type=county-district --pi_method=nonparametric --percent_reporting=20
```
because district was not in the unexpected data since that needs district to be an aggregate and if we didn't pass an aggregate into cli it was defaulting to postal_code only. So now we no longer default to postal_code but instead pass in no aggregate to the model from the cli in that case.

## Jira Ticket

## Test Steps
The above command should now work, also `tox`