### PR TITLE
some model parameters now also allow ints and not just floats

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -104,11 +104,11 @@ class ModelClient:
             ):
                 raise ValueError("lambda is not valid. It has to be numeric and greater than zero.")
             if "turnout_factor_lower" in model_parameters and not isinstance(
-                model_parameters["turnout_factor_lower"], float
+                model_parameters["turnout_factor_lower"], (float, int)
             ):
                 raise ValueError("turnout_factor_lower is not valid. Has to be a float.")
             if "turnout_factor_upper" in model_parameters and not isinstance(
-                model_parameters["turnout_factor_upper"], float
+                model_parameters["turnout_factor_upper"], (float, int)
             ):
                 raise ValueError("turnout_factor_upper is not valid. Has to be a float.")
             if pi_method == "gaussian":
@@ -130,32 +130,32 @@ class ModelClient:
                     model_parameters["agg_model_hard_threshold"], bool
                 ):
                     raise ValueError("agg_model_hard_threshold is not valid. Has to be a boolean.")
-                if "y_LB" in model_parameters and not isinstance(model_parameters["y_LB"], float):
+                if "y_LB" in model_parameters and not isinstance(model_parameters["y_LB"], (float, int)):
                     raise ValueError("y_LB is not valid. Has to be a float.")
-                if "y_UB" in model_parameters and not isinstance(model_parameters["y_UB"], float):
+                if "y_UB" in model_parameters and not isinstance(model_parameters["y_UB"], (float, int)):
                     raise ValueError("y_UB is not valid. Has to be a float.")
-                if "z_LB" in model_parameters and not isinstance(model_parameters["z_LB"], float):
+                if "z_LB" in model_parameters and not isinstance(model_parameters["z_LB"], (float, int)):
                     raise ValueError("z_LB is not valid. Has to be a float.")
-                if "z_UB" in model_parameters and not isinstance(model_parameters["z_UB"], float):
+                if "z_UB" in model_parameters and not isinstance(model_parameters["z_UB"], (float, int)):
                     raise ValueError("z_UB is not valid. Has to be a float.")
                 if "y_unobserved_upper_bound" in model_parameters and not isinstance(
-                    model_parameters["y_unobserved_upper_bound"], float
+                    model_parameters["y_unobserved_upper_bound"], (float, int)
                 ):
                     raise ValueError("y_unobserved_upper_bound is not valid. Has to be a float.")
                 if "y_unobserved_lower_bound" in model_parameters and not isinstance(
-                    model_parameters["y_unobserved_lower_bound"], float
+                    model_parameters["y_unobserved_lower_bound"], (float, int)
                 ):
                     raise ValueError("y_unobserved_lower_bound is not valid. Has to be a float.")
                 if "percent_expected_vote_error_bound" in model_parameters and not isinstance(
-                    model_parameters["percent_expected_vote_error_bound"], float
+                    model_parameters["percent_expected_vote_error_bound"], (float, int)
                 ):
                     raise ValueError("z_UB is not valid. Has to be a float.")
                 if "z_unobserved_upper_bound" in model_parameters and not isinstance(
-                    model_parameters["z_unobserved_upper_bound"], float
+                    model_parameters["z_unobserved_upper_bound"], (float, int)
                 ):
                     raise ValueError("z_unobserved_upper_bound is not valid. Has to be a float.")
                 if "z_unobserved_lower_bound" in model_parameters and not isinstance(
-                    model_parameters["z_unobserved_lower_bound"], float
+                    model_parameters["z_unobserved_lower_bound"], (float, int)
                 ):
                     raise ValueError("z_unobserved_lower_bound is not valid. Has to be a float.")
         if handle_unreporting not in {"drop", "zero"}:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,12 +20,7 @@ features = ["gender_f", "median_household_income"]
 aggregates = ["postal_code", "county_fips"]
 fixed_effects = []
 pi_method = "gaussian"
-model_parameters = {
-    "beta": 3,
-    "winsorize": False,
-    "robust": True,
-    "lambda_": 0,
-}
+model_parameters = {"beta": 3, "winsorize": False, "robust": True, "lambda_": 0, "y_LB": 1.0, "y_UB": 4}
 handle_unreporting = "drop"
 
 
@@ -42,6 +37,25 @@ def test_check_input_parameters(model_client, va_config):
         aggregates,
         fixed_effects,
         pi_method,
+        model_parameters,
+        handle_unreporting,
+    )
+
+
+def test_check_input_parameters_bootstrap(model_client, va_config):
+    # this is to test y_LB and y_UB
+    election_id = "2017-11-07_VA_G"
+    config_handler = ConfigHandler(election_id, config=va_config)
+
+    assert model_client._check_input_parameters(
+        config_handler,
+        office,
+        estimands,
+        geographic_unit_type,
+        features,
+        aggregates,
+        fixed_effects,
+        "bootstrap",
         model_parameters,
         handle_unreporting,
     )
@@ -293,6 +307,25 @@ def test_check_input_parameters_lambda_(model_client, va_config):
                 "robust": True,
                 "lambda_": -1,
             },
+            handle_unreporting,
+        )
+
+
+def test_check_input_parameters_y_UB_LB(model_client, va_config):
+    election_id = "2017-11-07_VA_G"
+    config_handler = ConfigHandler(election_id, config=va_config)
+
+    with pytest.raises(ValueError):
+        model_client._check_input_parameters(
+            config_handler,
+            office,
+            estimands,
+            geographic_unit_type,
+            features,
+            aggregates,
+            fixed_effects,
+            "bootstrap",
+            {"beta": 3, "winsorize": False, "robust": True, "lambda_": -1, "y_LB": "break", "y_UB": 1},
             handle_unreporting,
         )
 


### PR DESCRIPTION
## Description
Some model parameters should be numeric but are currently only accepted as floats by the model. This is causing issues with hasura, which converts floats to ints if they have a trailing zero if you change the parameters directly in the database. So this updates the model to let the parameters be both floats and ints.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-3460

## Test Steps
The following is throwing an error in develop branch, but not in this branch:
```
elexmodel 2017-11-07_VA_G --estimands=margin --office_id=G --geographic_unit_type=precinct --pi_method=bootstrap --percent_reporting=10 --aggregates=postal_code --fixed_effects=county_classification --features=baseline_normalized_margin  --model_parameters='{"B": 10, "y_unobserved_upper_bound": 2}'
```