### PR TITLE
fixed alpha bug

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -169,8 +169,8 @@ class ModelClient:
         raw_aggregate_list = base_aggregate + [aggregate]
         return sorted(list(set(raw_aggregate_list)), key=lambda x: AGGREGATE_ORDER.index(x))
 
-    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, called_states={}, base_to_add=0):
-        return self.model.get_national_summary_estimates(nat_sum_data_dict, called_states, base_to_add)
+    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, called_states={}, base_to_add=0, alpha=0.99):
+        return self.model.get_national_summary_estimates(nat_sum_data_dict, called_states, base_to_add, alpha)
 
     def get_estimates(
         self,


### PR DESCRIPTION
## Description
The bootstrap model function `get_national_summary_estimates` expected a parameter called `alpha` that set the size of the prediction interval. But the model client function `get_national_summary_votes_estimates` that invokes the model function didn't pass in an alpha.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-3461

## Test Steps
In the testbed run the model with `agg_model_preds=True` in develop, which should break. It should work in this branch.