### PR TITLE
Add predicted turnout to unit data

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -334,10 +334,10 @@ class ModelClient:
         )
 
         for estimand in estimands:
-            unit_predictions = self.model.get_unit_predictions(
+            unit_predictions, unit_turnout_predictions = self.model.get_unit_predictions(
                 reporting_units, nonreporting_units, estimand, unexpected_units=unexpected_units
             )
-            results_handler.add_unit_predictions(estimand, unit_predictions)
+            results_handler.add_unit_predictions(estimand, unit_predictions, unit_turnout_predictions)
             # gets prediciton intervals for each alpha
             alpha_to_unit_prediction_intervals = {}
             for alpha in prediction_intervals:

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -30,7 +30,7 @@ class ModelResultsHandler:
         self.nonreporting_units = nonreporting_units
         self.unexpected_units = unexpected_units
 
-    def add_unit_predictions(self, estimand, unit_predictions):
+    def add_unit_predictions(self, estimand, unit_predictions, unit_turnout_predictions):
         """
         unit_predictions: data frame with unit predictions, as produced by model.get_unit_predictions
 
@@ -38,6 +38,11 @@ class ModelResultsHandler:
         self.reporting_units[f"pred_{estimand}"] = self.reporting_units[f"results_{estimand}"]
         self.nonreporting_units[f"pred_{estimand}"] = unit_predictions
         self.unexpected_units[f"pred_{estimand}"] = self.unexpected_units[f"results_{estimand}"]
+
+        if unit_turnout_predictions is not None:
+            self.reporting_units["pred_turnout"] = self.reporting_units["results_weights"]
+            self.nonreporting_units["pred_turnout"] = unit_turnout_predictions
+            self.unexpected_units["pred_turnout"] = self.unexpected_units["results_weights"]
 
     def add_unit_intervals(self, estimand, prediction_intervals_unit):
         """
@@ -57,13 +62,13 @@ class ModelResultsHandler:
             self.nonreporting_units[upper_string] = prediction_intervals_unit[alpha].upper
             self.unexpected_units[lower_string] = self.unexpected_units[f"results_{estimand}"]
             self.unexpected_units[upper_string] = self.unexpected_units[f"results_{estimand}"]
-
         self.unit_data[estimand] = pd.concat(
             [self.reporting_units, self.nonreporting_units, self.unexpected_units]
         ).sort_values("geographic_unit_fips")[
             ["postal_code", "geographic_unit_fips", f"pred_{estimand}", "reporting"]
             + interval_cols
             + [f"results_{estimand}"]
+            + (["pred_turnout"] if estimand == "margin" else [])
         ]
 
     def add_agg_predictions(self, estimand, aggregate, estimates_df, agg_interval_predictions):
@@ -100,6 +105,7 @@ class ModelResultsHandler:
             self.final_results["unit_data"] = reduce(
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
             )
+
 
     def write_data(self, election_id, office, geographic_unit_type):
         """

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -106,7 +106,6 @@ class ModelResultsHandler:
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
             )
 
-
     def write_data(self, election_id, office, geographic_unit_type):
         """
         Saves dataframe of estimates for all estimands to S3

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1035,7 +1035,7 @@ class BootstrapElectionModel(BaseElectionModel):
         if not self.ran_bootstrap:
             unexpected_units = kwargs["unexpected_units"]
             self.compute_bootstrap_errors(reporting_units, nonreporting_units, unexpected_units)
-        return self.weighted_yz_test_pred
+        return self.weighted_yz_test_pred, self.weighted_z_test_pred
 
     def _is_top_level_aggregate(self, aggregate: list) -> bool:
         """

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -102,7 +102,7 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
         )
 
         # round since we don't need the artificial precision
-        return preds.round(decimals=0)
+        return preds.round(decimals=0), None
 
     def get_unit_prediction_interval_bounds(
         self,

--- a/tests/handlers/test_model_results.py
+++ b/tests/handlers/test_model_results.py
@@ -62,9 +62,9 @@ intervals2_e2 = {0.7: PredictionIntervals([2000], [2200]), 0.9: PredictionInterv
 def test_model_results_handler():
     # test unit predictions/intervals methods for two estimands
     handler = ModelResultsHandler(["district", "unit", "postal_code"], [0.7, 0.9], reporting, nonreporting, notexpected)
-    handler.add_unit_predictions("e1", predictions_e1)
+    handler.add_unit_predictions("e1", predictions_e1, None)
     handler.add_unit_intervals("e1", intervals_e1)
-    handler.add_unit_predictions("e2", predictions_e2)
+    handler.add_unit_predictions("e2", predictions_e2, None)
     handler.add_unit_intervals("e2", intervals_e2)
     expected_cols = [
         "pred_e1",
@@ -106,7 +106,7 @@ def test_model_results_handler():
 
 def test_no_unit_data():
     handler = ModelResultsHandler(["postal_code"], [0.7, 0.9], reporting, nonreporting, notexpected)
-    handler.add_unit_predictions("e1", predictions_e1)
+    handler.add_unit_predictions("e1", predictions_e1, None)
     handler.add_unit_intervals("e1", intervals_e1)
 
     handler.add_agg_predictions("e1", "postal_code", agg1_e1, intervals1_e1)

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -561,11 +561,12 @@ def test_get_unit_predictions(bootstrap_election_model, va_governor_county_data)
 
     bootstrap_election_model.B = 10
     assert not bootstrap_election_model.ran_bootstrap
-    unit_predictions = bootstrap_election_model.get_unit_predictions(
+    unit_predictions, unit_turnout_predictions = bootstrap_election_model.get_unit_predictions(
         reporting_units, nonreporting_units, estimand="margin", unexpected_units=unexpected_units
     )
     assert bootstrap_election_model.ran_bootstrap
     assert unit_predictions.shape == (nonreporting_units.shape[0], 1)
+    assert unit_turnout_predictions.shape == (nonreporting_units.shape[0], 1)
 
 
 def test_is_top_level_aggregate(bootstrap_election_model):
@@ -1023,7 +1024,7 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
 
     bootstrap_election_model.B = 300
 
-    unit_predictions = bootstrap_election_model.get_unit_predictions(
+    unit_predictions, unit_turnout_predictions = bootstrap_election_model.get_unit_predictions(
         reporting_units, nonreporting_units, "margin", unexpected_units=unexpected_units
     )
     unit_lower, unit_upper = bootstrap_election_model.get_unit_prediction_intervals(
@@ -1034,6 +1035,8 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
     assert unit_predictions.shape[0] == unit_upper.shape[0]
     assert all(unit_lower.flatten() <= unit_predictions.flatten())
     assert all(unit_predictions.flatten() <= unit_upper.flatten())
+
+    assert unit_turnout_predictions.shape == unit_predictions.shape
 
     reporting_units["pred_margin"] = reporting_units.results_margin
     nonreporting_units["pred_margin"] = unit_predictions


### PR DESCRIPTION
## Description
If we are running a margin model we need to save the turnout predictions also to be able to evaluate the model.

## Jira Ticket

## Test Steps
`tox`
also
```
elexmodel 2017-11-07_VA_G --estimands=margin --office_id=G --geographic_unit_type=precinct --pi_method=bootstrap --percent_reporting=10 --aggregates=postal_code --fixed_effects=county_classification --features=baseline_normalized_margin --aggregates=unit
```
Now includes `pred_turnout` for the `unit_data`