### PR TITLE
Fix warnings, update packages, get unit tests to pass again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from codecs import open
 from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = (
-    "click~=8.1",
+    "click>=8.1",
     "elex-solver>=2.0.1",
-    "pandas~=2.1",
-    "boto3~=1.28",
-    "python-dotenv~=1.0",
-    "scipy~=1.11",
+    "pandas>=2.2",
+    "boto3>=1.34",
+    "python-dotenv>=1.0",
+    "scipy>=1.14",
 )
 
 THIS_FILE_DIR = os.path.dirname(__file__)

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -516,7 +516,8 @@ class HistoricalModelClient(ModelClient):
                         x[f"raw_results_{estimand}"], x[f"pred_{estimand}"], type_="mape"
                     ),
                 }
-            )
+            ),
+            include_groups=False,
         )
 
         for alpha in prediction_intervals:
@@ -532,7 +533,8 @@ class HistoricalModelClient(ModelClient):
                             x[lower_string], x[upper_string], x[f"raw_results_{estimand}"]
                         ),
                     }
-                )
+                ),
+                include_groups=False,
             )
             error_df = error_df.merge(alpha_df, left_index=True, right_index=True)
 

--- a/src/elexmodel/distributions/GaussianModel.py
+++ b/src/elexmodel/distributions/GaussianModel.py
@@ -112,7 +112,8 @@ class GaussianModel:
                         "sigma_upper_bound": self.beta
                         * math_utils.boot_sigma(x.upper_bounds.values, conf=(3 + alpha) / 4, winsorize=self.winsorize),
                     }
-                )
+                ),
+                include_groups=False,
             )
             .reset_index(drop=drop_index)
         )

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -174,7 +174,8 @@ class GaussianElectionModel(ConformalElectionModel):
                         "nonreporting_weight_sum": np.sum(x[f"last_election_results_{estimand}"]),
                         "nonreporting_weight_ssum": np.sum(np.power(x[f"last_election_results_{estimand}"], 2)),
                     }
-                )
+                ),
+                include_groups=False,
             )
             .reset_index(drop=False)
         )

--- a/tests/distributions/test_gaussian_model.py
+++ b/tests/distributions/test_gaussian_model.py
@@ -74,11 +74,14 @@ def test_get_n_units_per_group_simple():
 
     # we now test this per group
     units_per_group = gaussian_model._get_n_units_per_group(df1, df2, ["c1"])
+    # setting the index to check the values
+    # since there's no way to guarantee merge order
+    units_per_group = units_per_group.set_index("c1")
 
-    assert units_per_group.iloc[0]["n"] == 1.0
-    assert units_per_group.iloc[1]["n"] == 2.0
-    assert units_per_group.iloc[2]["n"] == 0.0  # d is third since merginging df2 onto df1 and 0.0 because not in df1
-    assert units_per_group.iloc[3]["n"] == 1.0
+    assert units_per_group.loc["a"]["n"] == 1.0
+    assert units_per_group.loc["b"]["n"] == 2.0
+    assert units_per_group.loc["c"]["n"] == 1.0
+    assert units_per_group.loc["d"]["n"] == 0.0  # d is 0.0 because not in df1
 
 
 def test_get_n_units_per_group(va_governor_precinct_data):

--- a/tests/models/test_nonparametric_election_model.py
+++ b/tests/models/test_nonparametric_election_model.py
@@ -206,10 +206,10 @@ def test_aggregation_simple():
     df3 = model._get_reporting_aggregate_votes(df1, df2, aggregate=["c1", "c2"], estimand=estimand)
     assert pd.DataFrame(
         {
-            "c1": ["a", "a", "b", "b", "a", "d"],
-            "c2": ["x", "y", "y", "z", "w", "t"],
-            f"results_{estimand}": [5.0, 9.0, 1.0, 15.0, 5.0, 1.0],
-            "reporting": [2.0, 1.0, 1.0, 3.0, 1.0, 1.0],
+            "c1": ["a", "a", "a", "b", "b", "d"],
+            "c2": ["w", "x", "y", "y", "z", "t"],
+            f"results_{estimand}": [5.0, 5.0, 9.0, 1.0, 15.0, 1.0],
+            "reporting": [1.0, 2.0, 1.0, 1.0, 3.0, 1.0],
         }
     ).equals(df3)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py3.10,py3.11
+envlist=py3.11
 skipdist=True
 
 [base]


### PR DESCRIPTION
## Description

Hi!  The changes in this PR:

* update our dependencies to their latest versions,
* fix warnings brought about by virtue of updating said dependencies,
* ensure that our unit tests pass again,
* remove Python 3.10 from unit testing.

Note that there is still a warning coming from `cvxpy` regarding the fact that in `elex-solver`, we haven't explicitly specified which solver to use.  That will require a new `elex-solver` release at a later date; see [ELEX-4413].

## Jira Ticket

[ELEX-3581]

## Test Steps

`tox` 🎉 

[ELEX-4413]: https://arcpublishing.atlassian.net/browse/ELEX-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ELEX-3581]: https://arcpublishing.atlassian.net/browse/ELEX-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ