### PR TITLE
Output a `dict` of duplicate units and their counts

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -324,8 +324,8 @@ class ModelClient:
                 f"Currently {n_reporting_expected_units} reporting, need at least {minimum_reporting_units_max}"
             )
 
-        units_by_count = reporting_units.groupby("geographic_unit_fips").size()
-        duplicate_units = units_by_count[units_by_count > 1].tolist()
+        units_by_count = reporting_units["geographic_unit_fips"].value_counts()
+        duplicate_units = units_by_count[units_by_count > 1].to_dict()
         if len(duplicate_units) > 0:
             raise ModelClientException(f"At least one unit appears twice: {duplicate_units}")
 


### PR DESCRIPTION
## Description

Hi!  The change in this PR modifies the exception thrown when there are duplicate reporting units to output a dictionary of those units and their counts.  This should be helpful for debugging data and problems 👍🏻   Thanks!

## Jira Ticket

## Test Steps

Run the testbed with any data set known to contain duplicate units (e.g. `python run.py 2020-11-03_USA_G redo --office_id P --geographic_unit_type county --pi_method bootstrap --estimands "['margin']" --features "['baseline_normalized_margin']" --fixed_effects "['county_classification']" --start_timestamp "2020-11-10 06:30:12-05:00"`).