### PR TITLE
Handle division where `normalized_margin` numerator and denominator are 0

### DIFF
--- a/src/elexmodel/handlers/data/Estimandizer.py
+++ b/src/elexmodel/handlers/data/Estimandizer.py
@@ -114,5 +114,7 @@ def margin(data_df, col_prefix):
     generated_normalized_margin_column_name = f"{col_prefix}normalized_margin"
     data_df[generated_weights_column_name] = data_df[f"{col_prefix}dem"] + data_df[f"{col_prefix}gop"]
     data_df[generated_margin_column_name] = data_df[f"{col_prefix}dem"] - data_df[f"{col_prefix}gop"]
-    data_df[generated_normalized_margin_column_name] = data_df[f"{col_prefix}margin"] / data_df[f"{col_prefix}weights"]
+    data_df[generated_normalized_margin_column_name] = np.nan_to_num(
+        data_df[f"{col_prefix}margin"] / data_df[f"{col_prefix}weights"], nan=0, posinf=0, neginf=0
+    )
     return data_df, [generated_weights_column_name, generated_normalized_margin_column_name]

--- a/tests/handlers/test_estimandizer.py
+++ b/tests/handlers/test_estimandizer.py
@@ -69,3 +69,18 @@ def test_add_turnout_factor(va_governor_county_data):
 
     assert "turnout_factor" in output_df.columns
     assert 0 == pytest.approx(output_df.loc[0, "turnout_factor"])
+
+
+def test_add_margin_estimand_zero_normalized_margin(va_governor_county_data):
+    estimand_baselines = {"margin": None}
+    estimandizer = Estimandizer()
+
+    # test that we're handling zeros ok
+    test_df = va_governor_county_data.copy()
+    test_df.loc[1, "baseline_dem"] = 0
+    test_df.loc[1, "baseline_gop"] = 0
+
+    output_df = estimandizer.add_estimand_baselines(test_df, estimand_baselines, False, include_results_estimand=False)
+
+    assert "baseline_normalized_margin" in output_df.columns
+    assert test_df.loc[1, "baseline_normalized_margin"] == 0


### PR DESCRIPTION
## Description

Hi!  The change in this PR fixes an issue where the numerator (`margin`) and denominator (`weights`) used to compute `normalized_margin` could be 0.  This is probably most common when computing a `baseline_margin` estimand, when a unit's `baseline_dem` and `baseline_gop` are 0, resulting in `baseline_margin` and `baseline_weights` being 0.  I've also added a unit test for this case 🎉  Thanks!

## Jira Ticket

## Test Steps

This test bed command:
`python run.py 2022-11-08_USA_G redo --office_id S_precinct --fixed_effects "['county_classification']" --geographic_unit_type precinct --pi_method bootstrap --estimands "['margin']" --features "['baseline_normalized_margin', 'median_household_income', 'percent_bachelor_or_higher']" --end_timestamp "2022-11-09 10:31:27-05:00" --single_state IA`