### PR TITLE
Small agg model bug

### DIFF
--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1420,7 +1420,9 @@ class BootstrapElectionModel(BaseElectionModel):
         # for contests called for the RHS party. So this sum gives us the number of called contests for RHS
         called_contests_rhs = np.nansum(1 - called_states_sorted_vals)
 
-        # Our values should not be lower than the number of called
+        # Since the values should be greater than the called_contests_lhs we max with that and since they
+        # should be less than the called_contests_rhs we min with that. Also we add  in the base to account
+        # for uncontested races.
         agg_pred = min(max(aggregate_dem_vals_pred, called_contests_lhs), called_contests_rhs) + base_to_add
         agg_lower = min(max(interval_lower, called_contests_lhs), called_contests_rhs) + base_to_add
         agg_upper = min(max(interval_upper, called_contests_lhs), called_contests_rhs) + base_to_add

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1352,7 +1352,7 @@ class BootstrapElectionModel(BaseElectionModel):
         # we don't want the uncalled states to have a number to max/min
         # in order for those states to keep their original computed win probability
         called_states_sorted_vals[np.isclose(called_states_sorted_vals, -1)] = np.nan
-        
+
         # technically we do not need to do this division, since the margin
         # (ie. aggregate_error_B_1 and aggregate_error_B_2)
         # are enough to know who has won a contest (we don't need the normalized margin)
@@ -1413,22 +1413,17 @@ class BootstrapElectionModel(BaseElectionModel):
         # we max and min with the fewest possible seats that the LHS party might win (ie. the total number of ones that have
         # been called in their favor already) and we min with the highest possible seats that the LHS party might win (ie. the
         # total number of ones that have been called by the RHS party).
-        
+
         # this is the total number of 1s in called_states. Which is the number of contests called for the LHS party
         called_contests_lhs = np.nansum(called_states_sorted_vals)
         # since uncalled states are NaN in called_states_sorted_vals 1 - called_states_sorted_vals gives us a 1
         # for contests called for the RHS party. So this sum gives us the number of called contests for RHS
         called_contests_rhs = np.nansum(1 - called_states_sorted_vals)
 
+        # Our values should not be lower than the number of called
         agg_pred = min(max(aggregate_dem_vals_pred, called_contests_lhs), called_contests_rhs) + base_to_add
         agg_lower = min(max(interval_lower, called_contests_lhs), called_contests_rhs) + base_to_add
-        agg_upper = min(max(interval_upper, called_contests_lhs), called_contests_rhs)  + base_to_add
-        national_summary_estimates = {
-            "margin": [
-                agg_pred,
-                agg_lower,
-                agg_upper
-            ]
-        }
+        agg_upper = min(max(interval_upper, called_contests_lhs), called_contests_rhs) + base_to_add
+        national_summary_estimates = {"margin": [agg_pred, agg_lower, agg_upper]}
 
         return national_summary_estimates

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1410,14 +1410,19 @@ class BootstrapElectionModel(BaseElectionModel):
 
         # There is the small chance that because we sampled both components of the difference (ie error_B_1 and error_B_2)
         # that the values are off by 1 or 2 seats. To stop this from having effects on our prediction that are unreasonable
-        # we max and min with the fewest possible seats that the LHS party might win (ie. the total number of ones that have
-        # been called in their favor already) and we min with the highest possible seats that the LHS party might win (ie. the
-        # total number of ones that have been called by the RHS party).
+        # we max and min with the fewest aggregate value that the LHS party might win (ie. the total number of contests that
+        # have already been called in their favor times the value of each contest) and we min with the highest possible aggregate
+        # value that the LHS party might win (ie. their current agg value plus the agg value of the uncontested races) 
 
-        # this is the total number of 1s in called_states. Which is the number of contests called for the LHS party
+        # this is the aggregate value of the LHS party that have been already called 
+        # ie. the sum of of the number of called contests in the LHS favor times the contests values
         called_values_lhs = np.nansum(called_states_sorted_vals * nat_sum_data_dict_sorted_vals)
+        # the total agg value of the LHS *could* get is either the total value they do have already called plus
+        # the value of the uncalled races. That is equal to the total value of all contests minus the the value 
+        # of the races that have been called by the RHS party. Which is what we compute here.
         # since uncalled states are NaN in called_states_sorted_vals 1 - called_states_sorted_vals gives us a 1
-        # for contests called for the RHS party. So this sum gives us the number of called contests for RHS
+        # for contests called for the RHS party, which we then multiply by the value of the contests. We subtract this
+        # by the total value of the contests.
         called_values_rhs = np.sum(nat_sum_data_dict_sorted_vals) - np.nansum((1 - called_states_sorted_vals) * nat_sum_data_dict_sorted_vals)
 
         # Since the values should be greater than the called_values_lhs we max with that and since they

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1412,18 +1412,20 @@ class BootstrapElectionModel(BaseElectionModel):
         # that the values are off by 1 or 2 seats. To stop this from having effects on our prediction that are unreasonable
         # we max and min with the fewest aggregate value that the LHS party might win (ie. the total number of contests that
         # have already been called in their favor times the value of each contest) and we min with the highest possible aggregate
-        # value that the LHS party might win (ie. their current agg value plus the agg value of the uncontested races) 
+        # value that the LHS party might win (ie. their current agg value plus the agg value of the uncontested races)
 
-        # this is the aggregate value of the LHS party that have been already called 
+        # this is the aggregate value of the LHS party that have been already called
         # ie. the sum of of the number of called contests in the LHS favor times the contests values
         called_values_lhs = np.nansum(called_states_sorted_vals * nat_sum_data_dict_sorted_vals)
         # the total agg value of the LHS *could* get is either the total value they do have already called plus
-        # the value of the uncalled races. That is equal to the total value of all contests minus the the value 
+        # the value of the uncalled races. That is equal to the total value of all contests minus the the value
         # of the races that have been called by the RHS party. Which is what we compute here.
         # since uncalled states are NaN in called_states_sorted_vals 1 - called_states_sorted_vals gives us a 1
         # for contests called for the RHS party, which we then multiply by the value of the contests. We subtract this
         # by the total value of the contests.
-        called_values_rhs = np.sum(nat_sum_data_dict_sorted_vals) - np.nansum((1 - called_states_sorted_vals) * nat_sum_data_dict_sorted_vals)
+        called_values_rhs = np.sum(nat_sum_data_dict_sorted_vals) - np.nansum(
+            (1 - called_states_sorted_vals) * nat_sum_data_dict_sorted_vals
+        )
 
         # Since the values should be greater than the called_values_lhs we max with that and since they
         # should be less than the called_values_rhs we min with that. Also we add  in the base to account

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1338,6 +1338,7 @@ class BootstrapElectionModel(BaseElectionModel):
                 f"called_states is of length {len(called_states)} but there are {self.aggregate_error_B_1.shape[0]} contests"
             )
 
+        # NOTE: This assumes that pd.get_dummies does alphabetical ordering
         # sort in order to get in the same order as the contests,
         # which have been sorted when getting dummies for aggregate indicators
         # in get_aggregate_prediction_intervals

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1415,17 +1415,17 @@ class BootstrapElectionModel(BaseElectionModel):
         # total number of ones that have been called by the RHS party).
 
         # this is the total number of 1s in called_states. Which is the number of contests called for the LHS party
-        called_contests_lhs = np.nansum(called_states_sorted_vals)
+        called_values_lhs = np.nansum(called_states_sorted_vals * nat_sum_data_dict_sorted_vals)
         # since uncalled states are NaN in called_states_sorted_vals 1 - called_states_sorted_vals gives us a 1
         # for contests called for the RHS party. So this sum gives us the number of called contests for RHS
-        called_contests_rhs = np.nansum(1 - called_states_sorted_vals)
+        called_values_rhs = np.sum(nat_sum_data_dict_sorted_vals) - np.nansum((1 - called_states_sorted_vals) * nat_sum_data_dict_sorted_vals)
 
-        # Since the values should be greater than the called_contests_lhs we max with that and since they
-        # should be less than the called_contests_rhs we min with that. Also we add  in the base to account
+        # Since the values should be greater than the called_values_lhs we max with that and since they
+        # should be less than the called_values_rhs we min with that. Also we add  in the base to account
         # for uncontested races.
-        agg_pred = min(max(aggregate_dem_vals_pred, called_contests_lhs), called_contests_rhs) + base_to_add
-        agg_lower = min(max(interval_lower, called_contests_lhs), called_contests_rhs) + base_to_add
-        agg_upper = min(max(interval_upper, called_contests_lhs), called_contests_rhs) + base_to_add
+        agg_pred = min(max(aggregate_dem_vals_pred, called_values_lhs), called_values_rhs) + base_to_add
+        agg_lower = min(max(interval_lower, called_values_lhs), called_values_rhs) + base_to_add
+        agg_upper = min(max(interval_upper, called_values_lhs), called_values_rhs) + base_to_add
         national_summary_estimates = {"margin": [agg_pred, agg_lower, agg_upper]}
 
         return national_summary_estimates


### PR DESCRIPTION
## Description
As part of the hunt for the [2023 agg model bug ](https://arcpublishing.atlassian.net/browse/ELEX-3506) we identified a different, smaller bug that effects the intervals only (not the point prediction). On occasion the double sampling can create intervals that are slightly too wide.

We max the agg model predictions with the number of contests won by the LHS party since that is the minimum number of contests that party can win. We also min with the number of contests won by the RHS party since that is the maximum number they can win.

Also small change to finding the uncalled races to avoid floating point issues.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-4453

## Test Steps
```
python run.py 2023-11-07_VA_G redo --office_id Y --geographic_unit_type county-district --pi_method bootstrap --estimands "['margin']" --features "['baseline_normalized_margin']" --start_timestamp "2023-11-07 19:00:00+01:00" --current_run_name va-y-test --percent_ev_threshold 95 --agg_model_preds --base_to_add 20
```
in the testbed