### PR TITLE
ELEX-3469 save aggregate predictions to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Parameters for the CLI tool:
 | model_parameters     | dict    | dictionary of model specific parameters e.g. `--model_parameters='{"robust":True}'` |
 | save_output          | list    | `results`, `data`, `config` |
 | unexpected_units     | int     | number of unexpected units to simulate; only used for testing and does not work with historical run |
+| national_summary     | flag    | When not running a historical election, specify this flag to output national summary (aggregate model) estimates. |
 
 Note: When running the model with multiple fixed effects, make sure they are not linearly dependent. For example, `county_fips` and `county_classification` are linearly dependent when run together. That's because every county is in one county class, so all the fixed effect columns of the counties in the county class sum up to the fixed effect column of that county class.
 

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -168,7 +168,7 @@ def cli(
 
         if kwargs.get("national_summary", False):
             # TODO: get_national_summary_votes_estimates() arguments via CLI
-            model_client.get_national_summary_votes_estimates(None, None, 0, 0.99)
+            model_client.get_national_summary_votes_estimates(None, 0, 0.99)
 
         for aggregate_level, estimates in result.items():
             print(aggregate_level, "\n", estimates, "\n")

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -162,5 +162,10 @@ def cli(
             geographic_unit_type,
             **kwargs
         )
+
+        if kwargs.get("national_summary", False):
+            # TODO: get_national_summary_votes_estimates() arguments via CLI
+            model_client.get_national_summary_votes_estimates(None, None, 0, 0.99)
+
         for aggregate_level, estimates in result.items():
             print(aggregate_level, "\n", estimates, "\n")

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -76,6 +76,12 @@ class PythonLiteralOption(click.Option):
     help="options: results, data, config",
 )
 @click.option("--handle_unreporting", "handle_unreporting", default="drop", type=click.Choice(["drop", "zero"]))
+@click.option(
+    "--national_summary",
+    "national_summary",
+    is_flag=True,
+    help="When not running a historical election, output results aggregated to the national level.",
+)
 def cli(
     election_id, estimands, office_id, prediction_intervals, percent_reporting_threshold, geographic_unit_type, **kwargs
 ):

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -174,7 +174,6 @@ class ModelClient:
         raw_aggregate_list = base_aggregate + [aggregate]
         return sorted(list(set(raw_aggregate_list)), key=lambda x: AGGREGATE_ORDER.index(x))
 
-
     def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, base_to_add=0, alpha=0.99):
         if self.model is None:
             raise ModelClientException(
@@ -190,7 +189,6 @@ class ModelClient:
             )
 
         return nat_sum_estimates
-
 
     def get_estimates(
         self,

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -207,6 +207,7 @@ class ModelClient:
         # saving conformalization data only makes sense if a ConformalElectionModel is used
         save_conformalization = "conformalization" in save_output
         handle_unreporting = kwargs.get("handle_unreporting", "drop")
+        national_summary = kwargs.get("national_summary", False)
 
         district_election = False
         if office in {"H", "Y", "Z"}:
@@ -382,6 +383,12 @@ class ModelClient:
                 )
 
         results_handler.process_final_results()
+
+        if national_summary:
+            # TODO: parameters for self.get_national_summary_votes_estimates()
+            nat_sum_estimates = self.get_national_summary_votes_estimates(nat_sum_data_dict=None, called_states=None)
+            results_handler.add_national_summary_estimates(nat_sum_estimates)
+
         if APP_ENV != "local" and save_results:
             results_handler.write_data(election_id, office, geographic_unit_type)
 

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -383,9 +383,7 @@ class ModelClient:
 
         if national_summary:
             # TODO: arguments for self.model.get_national_summary_estimates
-            nat_sum_estimates = self.model.get_national_summary_estimates(
-                nat_sum_data_dict=None, called_states=None, base_to_add=0, alpha=0.99
-            )
+            nat_sum_estimates = self.model.get_national_summary_estimates(None, None, 0, 0.99)
             results_handler.add_national_summary_estimates(nat_sum_estimates)
 
         if APP_ENV != "local" and save_results:

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -169,9 +169,6 @@ class ModelClient:
         raw_aggregate_list = base_aggregate + [aggregate]
         return sorted(list(set(raw_aggregate_list)), key=lambda x: AGGREGATE_ORDER.index(x))
 
-    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, called_states={}, base_to_add=0, alpha=0.99):
-        return self.model.get_national_summary_estimates(nat_sum_data_dict, called_states, base_to_add, alpha)
-
     def get_estimates(
         self,
         current_data,  # list of lists
@@ -385,8 +382,10 @@ class ModelClient:
         results_handler.process_final_results()
 
         if national_summary:
-            # TODO: parameters for self.get_national_summary_votes_estimates()
-            nat_sum_estimates = self.get_national_summary_votes_estimates(nat_sum_data_dict=None, called_states=None)
+            # TODO: arguments for self.model.get_national_summary_estimates
+            nat_sum_estimates = self.model.get_national_summary_estimates(
+                nat_sum_data_dict=None, called_states=None, base_to_add=0, alpha=0.99
+            )
             results_handler.add_national_summary_estimates(nat_sum_estimates)
 
         if APP_ENV != "local" and save_results:

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -120,7 +120,7 @@ class ModelResultsHandler:
         )
         self.final_results["nat_sum_data"] = df
 
-    def write_data(self, election_id, office, geographic_unit_type):
+    def write_data(self, election_id, office, geographic_unit_type, keys=None):
         """
         Saves dataframe of estimates for all estimands to S3
         Different file by aggregate level
@@ -129,6 +129,8 @@ class ModelResultsHandler:
             self.process_final_results()
         s3_client = s3.S3CsvUtil(TARGET_BUCKET)
         for key, value in self.final_results.items():
+            if keys is not None and key not in keys:
+                continue
             path = f"{S3_FILE_PATH}/{election_id}/predictions/{office}/{geographic_unit_type}/{key}/current.csv"
             # convert df to csv
             csv_data = convert_df_to_csv(value)

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -25,6 +25,7 @@ class ModelResultsHandler:
         self.aggregates = [agg for agg in aggregates if agg != "unit"]
         self.estimates = {agg: [] for agg in self.aggregates}
         self.unit_data = {}
+        self.final_results = {}
 
         self.reporting_units = reporting_units
         self.nonreporting_units = nonreporting_units
@@ -93,7 +94,6 @@ class ModelResultsHandler:
         """
         Create final data frames of results
         """
-        self.final_results = {}
         for agg in self.aggregates:
             merge_on = ["postal_code", "reporting", agg]
             # joins together dfs of the same level of aggregation (different estimands)
@@ -105,6 +105,20 @@ class ModelResultsHandler:
             self.final_results["unit_data"] = reduce(
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
             )
+
+    def add_national_summary_estimates(self, national_summary_dict):
+        df = pd.DataFrame(
+            [
+                {
+                    "estimand": e,
+                    "agg_pred": national_summary_dict[e][0],
+                    "agg_lower": national_summary_dict[e][1],
+                    "agg_upper": national_summary_dict[e][2],
+                }
+                for e in national_summary_dict
+            ]
+        )
+        self.final_results["nat_sum_data"] = df
 
     def write_data(self, election_id, office, geographic_unit_type):
         """

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -107,18 +107,11 @@ class ModelResultsHandler:
             )
 
     def add_national_summary_estimates(self, national_summary_dict):
-        df = pd.DataFrame(
-            [
-                {
-                    "estimand": e,
-                    "agg_pred": national_summary_dict[e][0],
-                    "agg_lower": national_summary_dict[e][1],
-                    "agg_upper": national_summary_dict[e][2],
-                }
-                for e in national_summary_dict
-            ]
+        df = pd.DataFrame.from_dict(
+            national_summary_dict, orient="index", columns=["agg_pred", "agg_lower", "agg_upper"]
         )
-        self.final_results["nat_sum_data"] = df
+        df.index.name = "estimand"
+        self.final_results["nat_sum_data"] = df.reset_index()
 
     def write_data(self, election_id, office, geographic_unit_type, keys=None):
         """

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -172,5 +172,5 @@ class BaseElectionModel(ABC):
         """
         return self.features_to_coefficients
 
-    def get_national_summary_estimates(self, nat_sum_data_dict, called_states, base_to_add):
+    def get_national_summary_estimates(self, nat_sum_data_dict, called_states, base_to_add, alpha):
         raise NotImplementedError()

--- a/src/elexmodel/models/ConformalElectionModel.py
+++ b/src/elexmodel/models/ConformalElectionModel.py
@@ -206,5 +206,5 @@ class ConformalElectionModel(BaseElectionModel.BaseElectionModel, ABC):
         """
         raise NotImplementedError
 
-    def get_national_summary_estimates(self, nat_sum_data_dict, called_states, base_to_add):
+    def get_national_summary_estimates(self, nat_sum_data_dict, called_states, base_to_add, alpha):
         raise NotImplementedError()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -872,7 +872,7 @@ def test_get_national_summary_votes_estimates(model_client, va_governor_county_d
         **kwargs,
     )
 
-    current = model_client.get_national_summary_votes_estimates(None, None, 0, 0.99)
+    current = model_client.get_national_summary_votes_estimates(None, 0, 0.99)
 
     assert expected == current
     pd.testing.assert_frame_equal(expected_df, model_client.results_handler.final_results["nat_sum_data"])


### PR DESCRIPTION
## Description

Hi!  The changes in this PR allow us to save aggregate model output (national summary estimates) to s3.  It also provides a new CLI argument, `--national_summary`, which will produce aggregate model output via CLI 🎉   Hopefully I did this right 😬  Thanks!

## Jira Ticket

[ELEX-3469]

## Test Steps

Set `APP_ENV=dev` and `DATA_ENV=dev`, then run any command with `--national_summary`, e.g.:

```
elexmodel 2023-11-07_VA_G --estimands=margin --features=baseline_normalized_margin --office_id=Y --geographic_unit_type=county-district --save_output results --pi_method bootstrap --national_summary
```

[ELEX-3469]: https://arcpublishing.atlassian.net/browse/ELEX-3469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ