### PR TITLE
Elex 4455 add race call contest agg

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Parameters for the CLI tool:
 | aggregates           | list    | list of geographies for which to calculate predictions beyond the original `postal_code`, `county_fips`, `district`, `county_classification` |
 | pi_method            | string  | method for constructing prediction intervals (`nonparametric` or `gaussian`) |
 | model_parameters     | dict    | dictionary of model specific parameters e.g. `--model_parameters='{"robust":True}'` |
+| called_contests      | dict    | a dictionary of called contests. specific to Bootstrap model for now. e.g. `--called_contests='{"VA": -1}'` |
 | save_output          | list    | `results`, `data`, `config` |
 | unexpected_units     | int     | number of unexpected units to simulate; only used for testing and does not work with historical run |
 

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -53,11 +53,7 @@ class PythonLiteralOption(click.Option):
     help="A dictionary of model parameters",
 )
 @click.option(
-    "--called_contests",
-    "called_contests",
-    default="{}",
-    cls=PythonLiteralOption,
-    help="A dictionary with race calls"
+    "--called_contests", "called_contests", default="{}", cls=PythonLiteralOption, help="A dictionary with race calls"
 )
 @click.option(
     "--percent_reporting",

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -55,9 +55,9 @@ class PythonLiteralOption(click.Option):
 @click.option(
     "--called_contests",
     "called_contests",
-    default=None,
+    default="{}",
     cls=PythonLiteralOption,
-    help="A dictionar with race calls"
+    help="A dictionary with race calls"
 )
 @click.option(
     "--percent_reporting",

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -53,6 +53,13 @@ class PythonLiteralOption(click.Option):
     help="A dictionary of model parameters",
 )
 @click.option(
+    "--called_contests",
+    "called_contests",
+    default=None,
+    cls=PythonLiteralOption,
+    help="A dictionar with race calls"
+)
+@click.option(
     "--percent_reporting",
     "percent_reporting",
     default=100,

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -360,7 +360,7 @@ class ModelClient:
                     results_handler.unexpected_units,
                     aggregate_list,
                     estimand,
-                    called_contests=called_contests
+                    called_contests=called_contests,
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:
@@ -372,7 +372,7 @@ class ModelClient:
                         alpha,
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
-                        called_contests=called_contests
+                        called_contests=called_contests,
                     )
                     if isinstance(self.model, ConformalElectionModel):
                         self.all_conformalization_data_agg_dict[alpha][

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -169,8 +169,8 @@ class ModelClient:
         raw_aggregate_list = base_aggregate + [aggregate]
         return sorted(list(set(raw_aggregate_list)), key=lambda x: AGGREGATE_ORDER.index(x))
 
-    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, called_states={}, base_to_add=0, alpha=0.99):
-        return self.model.get_national_summary_estimates(nat_sum_data_dict, called_states, base_to_add, alpha)
+    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, base_to_add=0, alpha=0.99):
+        return self.model.get_national_summary_estimates(nat_sum_data_dict, base_to_add, alpha)
 
     def get_estimates(
         self,
@@ -200,6 +200,7 @@ class ModelClient:
         aggregates = kwargs.get("aggregates", DEFAULT_AGGREGATES[office])
         fixed_effects = kwargs.get("fixed_effects", {})
         pi_method = kwargs.get("pi_method", "nonparametric")
+        called_contests = kwargs.get("called_contests", None)
         save_output = kwargs.get("save_output", ["results"])
         save_results = "results" in save_output
         save_data = "data" in save_output
@@ -359,6 +360,7 @@ class ModelClient:
                     results_handler.unexpected_units,
                     aggregate_list,
                     estimand,
+                    called_contests=called_contests
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:
@@ -370,6 +372,7 @@ class ModelClient:
                         alpha,
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
+                        called_contests=called_contests
                     )
                     if isinstance(self.model, ConformalElectionModel):
                         self.all_conformalization_data_agg_dict[alpha][

--- a/src/elexmodel/models/BaseElectionModel.py
+++ b/src/elexmodel/models/BaseElectionModel.py
@@ -98,7 +98,7 @@ class BaseElectionModel(ABC):
         unexpected_units: pd.DataFrame,
         aggregate: list,
         estimand: str,
-        *kwargs,
+        **kwargs,
     ) -> pd.DataFrame:
         """
         Aggregate predictions and results by aggregate (ie. postal_code, county_fips etc.). Add results from reporting
@@ -158,7 +158,7 @@ class BaseElectionModel(ABC):
         unexpected_units: pd.DataFrame,
         aggregate: list,
         alpha: float,
-        *kwargs,
+        **kwargs,
     ) -> PredictionIntervals:
         """
         Generates and returns aggregate prediction intervals for arbitrary aggregates

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1086,7 +1086,7 @@ class BootstrapElectionModel(BaseElectionModel):
 
         return called_contests
 
-    def _call_contest(self, to_call: np.array, called_contests: dict) -> np.array:
+    def _adjust_called_contests(self, to_call: np.array, called_contests: dict) -> np.array:
         """
         This functions applies race calls to the point prediction
         """
@@ -1182,7 +1182,9 @@ class BootstrapElectionModel(BaseElectionModel):
         # which we will need for the national summary (e.g. ecv) model
         if self._is_top_level_aggregate(aggregate):
             called_contests = kwargs.get("called_contests")
-            self.aggregate_pred_margin = self._call_contest(raw_margin_df.pred_margin, called_contests).reshape(-1, 1)
+            self.aggregate_pred_margin = self._adjust_called_contests(
+                raw_margin_df.pred_margin, called_contests
+            ).reshape(-1, 1)
             raw_margin_df["pred_margin"] = self.aggregate_pred_margin
 
             aggregate_sum = all_units.groupby(aggregate_temp_column_name).sum()

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1321,12 +1321,13 @@ class BootstrapElectionModel(BaseElectionModel):
 
         lower_q, upper_q = self._get_quantiles(alpha)
 
+        error_diff = divided_error_B_1 - divided_error_B_2
+
         # saves the aggregate errors in case we want to generate somem form of national predictions (like ecv)
         if self._is_top_level_aggregate(aggregate):
             aggregate_perc_margin_total = self.aggregate_pred_margin
 
             called_contests = kwargs.get("called_contests")
-            error_diff = divided_error_B_1 - divided_error_B_2
             interval_upper, interval_lower = (aggregate_perc_margin_total - np.quantile(error_diff, q=[lower_q, upper_q], axis=-1).T).T
 
 

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1076,7 +1076,11 @@ class BootstrapElectionModel(BaseElectionModel):
             )
 
         called_contest_acceptable_values = {0, 1, -1}
-        if not all(any(math.isclose(value, acceptable_value) for acceptable_value in called_contest_acceptable_values) in called_contest_acceptable_values for value in called_contests.values()):
+        if not all(
+            any(math.isclose(value, acceptable_value) for acceptable_value in called_contest_acceptable_values)
+            in called_contest_acceptable_values
+            for value in called_contests.values()
+        ):
             raise BootstrapElectionModelException(
                 f"called_contest values need to be either 0, 1, or -1. But current value is {called_contests}"
             )

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1359,7 +1359,7 @@ class BootstrapElectionModel(BaseElectionModel):
             for i, (contest, call) in enumerate(sorted(called_contests.items(), key=lambda x: x[0])):
                 interval_lower_i = interval_lower[i]
                 interval_upper_i = interval_upper[i]
-                if call == 1:
+                if np.isclose(call, 1):
                     if interval_lower_i < 0:
                         # if a contest has been called for the LHS party but the interval_lower is below zero (ie. our model does not think that this is called)
                         # error_diff > 0 means that lower bound is smaller than the prediction, so for those we set the error_diff to be the gap between the prediction
@@ -1372,7 +1372,7 @@ class BootstrapElectionModel(BaseElectionModel):
                     # NOTE: we cannot do this for error_diff because we still want the upper bound in case to be what it would be without the race call
                     divided_error_B_1[i, :] = self.lhs_called_threshold
                     divided_error_B_2[i, :] = self.lhs_called_threshold
-                elif call == 0:
+                elif np.isclose(call, 0):
                     if interval_upper_i > 0:
                         # if a contest has been called for the RHS party but the interval_upper is larger than zero (ie. our model does not think this is called)
                         # error_diff < 0 means that the upper bound is larger than the prediction, so for those we set error_diff to be the gap between the prediction

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1069,7 +1069,7 @@ class BootstrapElectionModel(BaseElectionModel):
 
         # called_contests is a dictionary where 1 means that the LHS party has won, 0 means that the RHS party has won
         # and -1 means that the contest is not called. If called_contests is None, assume that all contests are not called.
-        if called_contests is None:
+        if called_contests is None or len(called_contests) == 0:
             called_contests = {i: -1 for i in range(to_call.shape[0])}
 
         if len(called_contests) != to_call.shape[0]:

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -86,10 +86,8 @@ class BootstrapElectionModel(BaseElectionModel):
         self.rng = np.random.default_rng(seed=self.seed)  # used for sampling
         self.ran_bootstrap = False
 
-        self.called_states = {'VA-47': 0, 'VA-50': 0, 'VA-51': 0, 'VA-53': 0, 'VA-55': 1, 'VA-61': 0, 'VA-62': 0, 'VA-89': 0, 'VA-64': 0, 'VA-65': 1, 'VA-66': 0, 'VA-70': 1, 'VA-71': 0, 'VA-73': 0, 'VA-75': 0, 'VA-82': 0, 'VA-60': 0, 'VA-76': 1, 'VA-83': 0, 'VA-84': 1, 'VA-41': 0, 'VA-33': 0, 'VA-86': 0, 'VA-87': 1, 'VA-88': 1, 'VA-90': 0, 'VA-93': 1, 'VA-94': 1, 'VA-96': 1, 'VA-34': 0, 'VA-97': 1, 'VA-99': 0, 'VA-72': 0, 'VA-31': 0, 'VA-11': 1, 'VA-30': 0, 'VA-52': 0, 'VA-91': 1, 'VA-92': 1, 'VA-100': 0, 'VA-6': 1, 'VA-7': 1, 'VA-8': 1, 'VA-9': 1, 'VA-10': 1, 'VA-14': 1, 'VA-15': 1, 'VA-18': 1, 'VA-21': 1, 'VA-32': 0, 'VA-36': 0, 'VA-37': 0, 'VA-40': 0, 'VA-57': 0, 'VA-58': 1, 'VA-59': 0, 'VA-23': 1, 'VA-20': 1, 'VA-22': 0, 'VA-25': 1, 'VA-26': 1, 'VA-27': 1, 'VA-28': 1, 'VA-29': 1, 'VA-67': 0}
-        self.called_states['VA-82'] = -1.0
-        self.called_states['VA-41'] = -1.0
-        self.called_states['VA-21'] = -1.0
+        # these are the max/min values for called races. Ie. if a contest is called for LHS party then the prediction/intervals should be at least lhs_called_threshold
+        # if a contest is called for RHS party then the prediction/interval should be at most rhs_called_threshold (at most because the values are negative)
         self.lhs_called_threshold = 0.005
         self.rhs_called_threshold = -0.005
 
@@ -1062,17 +1060,38 @@ class BootstrapElectionModel(BaseElectionModel):
             len(aggregate) == 2 and "postal_code" in aggregate and "district" in aggregate
         )
 
-    def _call_contest(self, to_call: np.array) -> np.array:
-        called_states_sorted = sorted(self.called_states.items())
-        called_states_min_max_values = np.asarray([self.lhs_called_threshold if y == 1 else self.rhs_called_threshold if y == 0 else math.nan for x, y in called_states_sorted]).reshape(-1, 1)
+    def _call_contests(self, to_call: np.array, called_contests: dict) -> np.array:
+        """
+        Function to call contests.
+        This takes bootstrap predictions and forces them to greater than or less than zero depending on how the race has been called
+        The function is agnostic to whether this is being applied to predictions or intervals
+        """
+
+        # called_contests is a dictionary where 1 means that the LHS party has won, 0 means that the RHS party has won
+        # and -1 means that the contest is not called. If called_contests is None, assume that all contests are not called.
+        if called_contests is None:
+            called_contests = {i: -1 for i in range(to_call.shape[0])}
+
+        if len(called_contests) != to_call.shape[0]:
+            raise BootstrapElectionModelException(
+                f"called_states is of length {len(called_contests)} but there are {to_call.shape[0]} contests"
+            )
+
+        # If contest i is called for the LHS party (ie. called_contest[i] == 1), then the margin should be above zero so the prediction
+        # and intervals should always be greater then self.lhs_called_threshold
+        # If contest i is called for the RHS party (ie. called_contest[i] == 0), then the margin should be less than zero so the prediction
+        # and intervals should always be less than self.rhs_called_threshold
+        # if contest i is not called then we use math.nan
+        called_contests_sorted = sorted(called_contests.items())
+        called_contests_min_max_values = np.asarray([self.lhs_called_threshold if y == 1 else self.rhs_called_threshold if y == 0 else math.nan for x, y in called_contests_sorted]).reshape(-1, 1)
 
         called = np.where(
-            np.isnan(called_states_min_max_values), 
-            to_call, 
+            np.isnan(called_contests_min_max_values), 
+            to_call, # if contest i is uncalled then we continue to use the value that was present before
             np.where(
-                called_states_min_max_values == self.lhs_called_threshold, 
-                np.maximum(to_call, self.lhs_called_threshold), 
-                np.minimum(to_call, self.rhs_called_threshold)
+                called_contests_min_max_values == self.lhs_called_threshold, # if contest i is called for LHS party 
+                np.maximum(to_call, self.lhs_called_threshold), # then value is max of what is was and lhs_called_threshold
+                np.minimum(to_call, self.rhs_called_threshold) # in this case the contest is called for RHS party so the value should be min of what it was and rhs_called_threshold (min because negative)
             )
         )
 
@@ -1086,6 +1105,7 @@ class BootstrapElectionModel(BaseElectionModel):
         unexpected_units: pd.DataFrame,
         aggregate: list,
         estimand: str,
+        **kwargs: dict
     ) -> pd.DataFrame:
         """
         Generates and returns the normalized margin for arbitrary aggregates
@@ -1142,11 +1162,13 @@ class BootstrapElectionModel(BaseElectionModel):
         # to get the normalized margin for the aggregate
         # turnout prediction could be zero, in which case predicted margin is also zero,
         # so replace NaNs with zero in that case
-        raw_margin_df["pred_margin"] = self._call_contest(np.nan_to_num(raw_margin_df.pred_margin / aggregate_z_total.flatten()).reshape(-1, 1))
+        raw_margin_df["pred_margin"] = np.nan_to_num(raw_margin_df.pred_margin / aggregate_z_total.flatten()).reshape(-1, 1)
         raw_margin_df["results_margin"] = np.nan_to_num(raw_margin_df.results_margin / aggregate_z_total.flatten())
         # if we are in the top level prediction, then save the aggregated baseline margin,
         # which we will need for the national summary (e.g. ecv) model
         if self._is_top_level_aggregate(aggregate):
+            called_contests = kwargs.get("called_contests")
+            raw_margin_df["pred_margin"] = self._call_contests(raw_margin_df.pred_margin.values.reshape(-1, 1), called_contests)
             aggregate_sum = all_units.groupby(aggregate_temp_column_name).sum()
             self.aggregate_baseline_margin = (
                 (aggregate_sum.baseline_dem - aggregate_sum.baseline_gop) / (aggregate_sum.baseline_turnout + 1)
@@ -1207,6 +1229,7 @@ class BootstrapElectionModel(BaseElectionModel):
         alpha: float,
         unit_prediction_intervals: PredictionIntervals,
         estimand: str,
+        **kwargs: dict
     ) -> PredictionIntervals:
         """
         Generate and return aggregate prediction intervals for arbitrary aggregates
@@ -1282,17 +1305,12 @@ class BootstrapElectionModel(BaseElectionModel):
         aggregate_error_B_4 = aggregate_z_total_pred
 
         # (sum_{i = 1}^N w_i * \tilde_{y_i}^b * \tilde_{z_i}^b) /  (\sum_{i = 1}^N w_i * \tilde_{z_i}^b)
-        divided_error_B_1 = self._call_contest(np.nan_to_num(aggregate_error_B_1 / aggregate_error_B_3))
+        divided_error_B_1 = np.nan_to_num(aggregate_error_B_1 / aggregate_error_B_3)
 
         # (\sum_{i = 1}^N w_i * (\hat_{y_i} + \residual_{y, i}^b) *
         # (\hat{z_i} + \residual_{z, i}^b)) /
         # (\sum_{i = 1}^N w_i * (\hat{z_i} + \residual_{z, i}^b))
-        divided_error_B_2 = self._call_contest(np.nan_to_num(aggregate_error_B_2 / aggregate_error_B_4))
-
-        # subtract to get bootstrap error for estimate in our predictions
-        aggregate_error_B = divided_error_B_1 - divided_error_B_2
-
-        lower_q, upper_q = self._get_quantiles(alpha)
+        divided_error_B_2 = np.nan_to_num(aggregate_error_B_2 / aggregate_error_B_4)
 
         # we also need to re-compute our aggregate prediction to add to our error to get the prediction interval
         # first the turnout component
@@ -1305,13 +1323,20 @@ class BootstrapElectionModel(BaseElectionModel):
         )
         # calculate normalized margin in the aggregate prediction
         # turnout prediction could be zero, so convert NaN -> 0
-        aggregate_perc_margin_total = self._call_contest(np.nan_to_num(aggregate_yz_total / aggregate_z_total).reshape(-1, 1))
+        aggregate_perc_margin_total = np.nan_to_num(aggregate_yz_total / aggregate_z_total).reshape(-1, 1)
 
         # saves the aggregate errors in case we want to generate somem form of national predictions (like ecv)
         if self._is_top_level_aggregate(aggregate):
+            called_contests = kwargs.get("called_contests")
+            divided_error_B_1 = self._call_contests(divided_error_B_1, called_contests)
+            divided_error_B_2 = self._call_contests(divided_error_B_2, called_contests)
+            aggregate_perc_margin_total = self._call_contests(aggregate_perc_margin_total, called_contests)
+
             self.divided_error_B_1 = divided_error_B_1
             self.divided_error_B_2 = divided_error_B_2
             self.aggregate_perc_margin_total = aggregate_perc_margin_total
+
+        lower_q, upper_q = self._get_quantiles(alpha)
 
         interval_upper, interval_lower = (aggregate_perc_margin_total - np.quantile(divided_error_B_1 - divided_error_B_2, q=[lower_q, upper_q], axis=-1).T).T
         interval_upper = interval_upper.reshape(-1, 1)
@@ -1320,7 +1345,7 @@ class BootstrapElectionModel(BaseElectionModel):
         return PredictionIntervals(interval_lower, interval_upper)
 
     def get_national_summary_estimates(
-        self, nat_sum_data_dict: dict, called_states: dict, base_to_add: int | float, alpha: float
+        self, nat_sum_data_dict: dict, base_to_add: int | float, alpha: float
     ) -> list:
         """
         Generates and returns a national summary estimate (ie. electoral votes or total number of senate seats).
@@ -1349,16 +1374,6 @@ class BootstrapElectionModel(BaseElectionModel):
                 f"nat_sum_data_dict is of length {len(nat_sum_data_dict)} but there are {self.divided_error_B_1.shape[0]} contests"
             )
 
-        # called states is a dictionary where 1 means that the LHS party has one, 0 means that the RHS party has won
-        # and -1 means that the state is not called. If called_states is None, assume that all states are not called.
-        if called_states is None:
-            called_states = {i: -1 for i in range(self.divided_error_B_1.shape[0])}
-
-        if len(called_states) != self.divided_error_B_1.shape[0]:
-            raise BootstrapElectionModelException(
-                f"called_states is of length {len(called_states)} but there are {self.divided_error_B_1.shape[0]} contests"
-            )
-
         # NOTE: This assumes that pd.get_dummies does alphabetical ordering
         # sort in order to get in the same order as the contests,
         # which have been sorted when getting dummies for aggregate indicators
@@ -1366,39 +1381,12 @@ class BootstrapElectionModel(BaseElectionModel):
         nat_sum_data_dict_sorted = sorted(nat_sum_data_dict.items())
         nat_sum_data_dict_sorted_vals = np.asarray([x[1] for x in nat_sum_data_dict_sorted]).reshape(-1, 1)
 
-        called_states_sorted = sorted(called_states.items())
-        called_states_sorted_vals = (
-            np.asarray([x[1] for x in called_states_sorted]).reshape(-1, 1) * 1.0
-        )  # multiplying by 1.0 to turn into floats
-        # since we max/min the state called values with contest win probabilities,
-        # we don't want the uncalled states to have a number to max/min
-        # in order for those states to keep their original computed win probability
-        called_states_sorted_vals[np.isclose(called_states_sorted_vals, -1)] = np.nan
-
-        # technically we do not need to do this division, since the margin
-        # (ie. aggregate_error_B_1 and aggregate_error_B_2)
-        # are enough to know who has won a contest (we don't need the normalized margin)
-        # but we normalize so that the temperature we use to set aggressiveness of sigmoid is in the right scale
-
         if self.hard_threshold:
             aggregate_dem_prob_B_1 = self.divided_error_B_1 > 0.5
             aggregate_dem_prob_B_1 = self.divided_error_B_2 > 0.5
         else:
             aggregate_dem_prob_B_1 = expit(self.T * self.divided_error_B_1)
             aggregate_dem_prob_B_2 = expit(self.T * self.divided_error_B_2)
-
-        # since called_states_sorted_vals has value 1 if the state is called for the LHS party,
-        # maxing the probabilities gives a probability of 1 for the LHS party
-        # and called_states_sorted_vals has value 0 if the state is called for the RHS party,
-        # so mining with probabilities gives a probability of 0 for the LHS party
-        # and called_states_sorted_vals has value np.nan if the state is uncalled,
-        # since we use fmax/fmin the actual number and not nan gets propagated, so we maintain the probability
-        # aggregate_dem_prob_B_1_called = np.fmin(
-        #     np.fmax(aggregate_dem_prob_B_1, called_states_sorted_vals), called_states_sorted_vals
-        # )
-        # aggregate_dem_prob_B_2_called = np.fmin(
-        #     np.fmax(aggregate_dem_prob_B_2, called_states_sorted_vals), called_states_sorted_vals
-        # )
 
         # multiply by weights of each contest
         aggregate_dem_vals_B_1 = nat_sum_data_dict_sorted_vals * aggregate_dem_prob_B_1
@@ -1413,11 +1401,7 @@ class BootstrapElectionModel(BaseElectionModel):
         else:
             aggregate_dem_probs_total = expit(self.T * self.aggregate_perc_margin_total)
 
-        # same as for the intervals
-        aggregate_dem_probs_total_called = np.fmin(
-            np.fmax(aggregate_dem_probs_total, called_states_sorted_vals), called_states_sorted_vals
-        )
-        aggregate_dem_vals_pred = np.sum(nat_sum_data_dict_sorted_vals * aggregate_dem_probs_total_called)
+        aggregate_dem_vals_pred = np.sum(nat_sum_data_dict_sorted_vals * aggregate_dem_probs_total)
 
         lower_q, upper_q = self._get_quantiles(alpha)
 
@@ -1425,30 +1409,8 @@ class BootstrapElectionModel(BaseElectionModel):
             aggregate_dem_vals_pred - np.quantile(aggregate_dem_vals_B, q=[lower_q, upper_q], axis=-1).T
         ).T
 
-        # There is the small chance that because we sampled both components of the difference (ie error_B_1 and error_B_2)
-        # that the values are off by 1 or 2 seats. To stop this from having effects on our prediction that are unreasonable
-        # we max and min with the fewest aggregate value that the LHS party might win (ie. the total number of contests that
-        # have already been called in their favor times the value of each contest) and we min with the highest possible aggregate
-        # value that the LHS party might win (ie. their current agg value plus the agg value of the uncontested races)
-
-        # this is the aggregate value of the LHS party that have been already called
-        # ie. the sum of of the number of called contests in the LHS favor times the contests values
-        called_values_lhs = np.nansum(called_states_sorted_vals * nat_sum_data_dict_sorted_vals)
-        # the total agg value of the LHS *could* get is either the total value they do have already called plus
-        # the value of the uncalled races. That is equal to the total value of all contests minus the the value
-        # of the races that have been called by the RHS party. Which is what we compute here.
-        # since uncalled states are NaN in called_states_sorted_vals 1 - called_states_sorted_vals gives us a 1
-        # for contests called for the RHS party, which we then multiply by the value of the contests. We subtract this
-        # by the total value of the contests.
-        called_values_rhs = np.sum(nat_sum_data_dict_sorted_vals) - np.nansum(
-            (1 - called_states_sorted_vals) * nat_sum_data_dict_sorted_vals
-        )
-
-        # Since the values should be greater than the called_values_lhs we max with that and since they
-        # should be less than the called_values_rhs we min with that. Also we add  in the base to account
-        # for uncontested races.
-        agg_pred = min(max(aggregate_dem_vals_pred, called_values_lhs), called_values_rhs) + base_to_add
-        agg_lower = min(max(interval_lower, called_values_lhs), called_values_rhs) + base_to_add
-        agg_upper = min(max(interval_upper, called_values_lhs), called_values_rhs) + base_to_add
+        agg_pred = aggregate_dem_vals_pred + base_to_add
+        agg_lower = interval_lower + base_to_add
+        agg_upper = interval_upper + base_to_add
         national_summary_estimates = {"margin": [agg_pred, agg_lower, agg_upper]}
         return national_summary_estimates

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # pylint: disable=too-many-lines
 
 import logging
+import math
 
 import numpy as np
 import pandas as pd
@@ -1075,7 +1076,7 @@ class BootstrapElectionModel(BaseElectionModel):
             )
 
         called_contest_acceptable_values = {0, 1, -1}
-        if not all(value in called_contest_acceptable_values for value in called_contests.values()):
+        if not all(any(math.isclose(value, acceptable_value) for acceptable_value in called_contest_acceptable_values) in called_contest_acceptable_values for value in called_contests.values()):
             raise BootstrapElectionModelException(
                 f"called_contest values need to be either 0, 1, or -1. But current value is {called_contests}"
             )

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations  # pylint: disable=too-many-lines
 
 import logging
-import math
 
 import numpy as np
 import pandas as pd
@@ -1077,7 +1076,7 @@ class BootstrapElectionModel(BaseElectionModel):
 
         called_contest_acceptable_values = {0, 1, -1}
         if not all(
-            any(math.isclose(value, acceptable_value) for acceptable_value in called_contest_acceptable_values)
+            any(np.isclose(value, acceptable_value) for acceptable_value in called_contest_acceptable_values)
             in called_contest_acceptable_values
             for value in called_contests.values()
         ):

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -114,6 +114,7 @@ class GaussianElectionModel(ConformalElectionModel):
         alpha: float,
         unit_prediction_intervals: PredictionIntervals,
         estimand: str,
+        **kwargs
     ) -> PredictionIntervals:
         """
         Get aggregate prediction intervals. Adjust aggregate prediction intervals based on Gaussian models

--- a/src/elexmodel/models/GaussianElectionModel.py
+++ b/src/elexmodel/models/GaussianElectionModel.py
@@ -114,7 +114,7 @@ class GaussianElectionModel(ConformalElectionModel):
         alpha: float,
         unit_prediction_intervals: PredictionIntervals,
         estimand: str,
-        **kwargs
+        **kwargs,
     ) -> PredictionIntervals:
         """
         Get aggregate prediction intervals. Adjust aggregate prediction intervals based on Gaussian models

--- a/src/elexmodel/models/NonparametricElectionModel.py
+++ b/src/elexmodel/models/NonparametricElectionModel.py
@@ -128,6 +128,7 @@ class NonparametricElectionModel(ConformalElectionModel):
         alpha: float,
         unit_prediction_intervals: PredictionIntervals,
         estimand: str,
+        **kwargs,
     ) -> PredictionIntervals:
         """
         Get aggregate prediction intervals. In the non-parametric case prediction intervals just sum.

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -654,8 +654,8 @@ def test_aggregate_predictions(bootstrap_election_model):
     )
     with pytest.raises(AttributeError):
         bootstrap_election_model.aggregate_baseline_margin
-    
-    bootstrap_election_model.n_contests = 6 # a through f
+
+    bootstrap_election_model.n_contests = 6  # a through f
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
     )
@@ -707,7 +707,7 @@ def test_aggregate_predictions(bootstrap_election_model):
 
     # test more complicated aggregate (postal code-district)
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
-    bootstrap_election_model.n_contests = 8 # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
+    bootstrap_election_model.n_contests = 8  # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
 
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin"
@@ -891,8 +891,10 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     bootstrap_election_model.weighted_z_test_pred = rng.normal(scale=s, size=(n, 1))
     bootstrap_election_model.weighted_yz_test_pred = rng.normal(scale=s, size=(n, 1))
 
-    bootstrap_election_model.n_contests = 6 # a through f
-    bootstrap_election_model.get_aggregate_predictions(reporting_units, nonreporting_units, unexpected_units, ['postal_code'], "margin")
+    bootstrap_election_model.n_contests = 6  # a through f
+    bootstrap_election_model.get_aggregate_predictions(
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
+    )
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], 0.95, None, None
     )
@@ -905,8 +907,10 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert all(lower <= upper)
 
     # test with more complicated aggregate
-    bootstrap_election_model.n_contests = 8 # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
-    bootstrap_election_model.get_aggregate_predictions(reporting_units, nonreporting_units, unexpected_units, ['postal_code', 'district'], "margin")
+    bootstrap_election_model.n_contests = 8  # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
+    bootstrap_election_model.get_aggregate_predictions(
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin"
+    )
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], 0.95, None, None
     )
@@ -931,12 +935,15 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     bootstrap_election_model.aggregate_error_B_2 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_3 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_4 = rng.normal(scale=s, size=(n, B))
-    bootstrap_election_model.divided_error_B_1 = np.nan_to_num(bootstrap_election_model.aggregate_error_B_1 / bootstrap_election_model.aggregate_error_B_3)
-    bootstrap_election_model.divided_error_B_2 = np.nan_to_num(bootstrap_election_model.aggregate_error_B_2 / bootstrap_election_model.aggregate_error_B_4)
+    bootstrap_election_model.divided_error_B_1 = np.nan_to_num(
+        bootstrap_election_model.aggregate_error_B_1 / bootstrap_election_model.aggregate_error_B_3
+    )
+    bootstrap_election_model.divided_error_B_2 = np.nan_to_num(
+        bootstrap_election_model.aggregate_error_B_2 / bootstrap_election_model.aggregate_error_B_4
+    )
 
     bootstrap_election_model.aggregate_perc_margin_total = rng.normal(scale=s, size=(n, 1))
 
-    
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
     assert "margin" in nat_sum_estimates
     assert len(nat_sum_estimates["margin"]) == 3
@@ -946,9 +953,15 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     # testing adding to base
     base_to_add = rng.random()
     nat_sum_estimates_w_base = bootstrap_election_model.get_national_summary_estimates(None, base_to_add, 0.95)
-    assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(round(nat_sum_estimates["margin"][0] + base_to_add), 2)
-    assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(round(nat_sum_estimates["margin"][1] + base_to_add), 2)
-    assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(round(nat_sum_estimates["margin"][2] + base_to_add), 2)
+    assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(
+        round(nat_sum_estimates["margin"][0] + base_to_add), 2
+    )
+    assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(
+        round(nat_sum_estimates["margin"][1] + base_to_add), 2
+    )
+    assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(
+        round(nat_sum_estimates["margin"][2] + base_to_add), 2
+    )
 
     nat_sum_data_dict = {i: 3 for i in range(n)}
     nat_sum_data_dict[1] = 7
@@ -956,9 +969,7 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     # test exception
     nat_sum_data_dict = {i: 3 for i in range(n - 1)}
     with pytest.raises(BootstrapElectionModelException):
-        nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-            nat_sum_data_dict, 0, 0.95
-        )
+        nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(nat_sum_data_dict, 0, 0.95)
 
 
 # TODO: write unit test for combined aggregation (e.g. prediction, intervals, aggregate etc.)

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -1050,7 +1050,7 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
         ["postal_code"],
         "margin",
         called_contests=called_contests,
-    ) # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1074,7 +1074,7 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
         ["postal_code"],
         "margin",
         called_contests=called_contests,
-    ) # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1190,27 +1190,17 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     bootstrap_election_model.errors_B_2 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.errors_B_3 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.errors_B_4 = rng.normal(scale=s, size=(n, B))
-    
+
     bootstrap_election_model.weighted_z_test_pred = rng.normal(scale=s, size=(n, 1))
     bootstrap_election_model.weighted_yz_test_pred = rng.normal(scale=s, size=(n, 1))
 
     bootstrap_election_model.n_contests = 6
 
     bootstrap_election_model.get_aggregate_predictions(
-        reporting_units,
-        nonreporting_units,
-        unexpected_units,
-        ["postal_code"],
-        "margin"
-    ) # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
-        reporting_units,
-        nonreporting_units,
-        unexpected_units,
-        ["postal_code"],
-        0.95,
-        None,
-        None
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], 0.95, None, None
     )
 
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
@@ -1219,19 +1209,18 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     assert nat_sum_estimates["margin"][0] >= nat_sum_estimates["margin"][1]
     assert nat_sum_estimates["margin"][0] <= nat_sum_estimates["margin"][2]
 
-
     # adding race call
     called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}
     called_contests[0] = -1
     called_contests[1] = -1
-    pred = bootstrap_election_model.get_aggregate_predictions(
+    bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
         unexpected_units,
         ["postal_code"],
         "margin",
         called_contests=called_contests,
-    ) # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1243,21 +1232,21 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
         called_contests=called_contests,
     )
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
-    assert nat_sum_estimates['margin'][0] == 5 # the 4 called ones plus the second one
-    assert nat_sum_estimates['margin'][1] == 4 # the 4 called ones
-    assert nat_sum_estimates['margin'][2] == 6 # all of them
+    assert nat_sum_estimates["margin"][0] == 5  # the 4 called ones plus the second one
+    assert nat_sum_estimates["margin"][1] == 4  # the 4 called ones
+    assert nat_sum_estimates["margin"][2] == 6  # all of them
 
     called_contests = {x: 0 for x in range(bootstrap_election_model.n_contests)}
     called_contests[0] = -1
     called_contests[1] = -1
-    pred = bootstrap_election_model.get_aggregate_predictions(
+    bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
         unexpected_units,
         ["postal_code"],
         "margin",
         called_contests=called_contests,
-    ) # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1269,10 +1258,9 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
         called_contests=called_contests,
     )
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
-    assert nat_sum_estimates['margin'][0] == 1 # the 2nd one, only not called for RHS
-    assert nat_sum_estimates['margin'][1] == 0 # might lose the 2nd one also
-    assert nat_sum_estimates['margin'][2] == 2 # 2nd and first
-
+    assert nat_sum_estimates["margin"][0] == 1  # the 2nd one, only not called for RHS
+    assert nat_sum_estimates["margin"][1] == 0  # might lose the 2nd one also
+    assert nat_sum_estimates["margin"][2] == 2  # 2nd and first
 
     # testing adding to base
     base_to_add = rng.random()

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -617,7 +617,7 @@ def test_format_called_contests_dictionary(bootstrap_election_model, rng):
     assert called_contests == bootstrap_election_model._format_called_contests_dictionary(called_contests)
 
 
-def test_call_contest(bootstrap_election_model, rng):
+def test_adjust_called_contests(bootstrap_election_model, rng):
     n_contests = 10
     bootstrap_election_model.n_contests = n_contests
 
@@ -630,7 +630,7 @@ def test_call_contest(bootstrap_election_model, rng):
 
     to_call = np.asarray([0.3, -0.3, 0.2, -0.4, 0.15, -0.25, 0.86, -0.74, -0.3, 0.3])
 
-    called = bootstrap_election_model._call_contest(to_call, called_contests)
+    called = bootstrap_election_model._adjust_called_contests(to_call, called_contests)
     assert called.shape == (n_contests,)
     assert called[0] == to_call[0]  # since called for LHS and positive should remain the same
     assert (

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -646,7 +646,6 @@ def test_aggregate_predictions(bootstrap_election_model):
             "district",
         ],
     )
-
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
     # test that is top level aggregate is working
@@ -655,7 +654,8 @@ def test_aggregate_predictions(bootstrap_election_model):
     )
     with pytest.raises(AttributeError):
         bootstrap_election_model.aggregate_baseline_margin
-
+    
+    bootstrap_election_model.n_contests = 6 # a through f
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
     )
@@ -707,6 +707,8 @@ def test_aggregate_predictions(bootstrap_election_model):
 
     # test more complicated aggregate (postal code-district)
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
+    bootstrap_election_model.n_contests = 8 # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
+
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin"
     )
@@ -889,6 +891,8 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     bootstrap_election_model.weighted_z_test_pred = rng.normal(scale=s, size=(n, 1))
     bootstrap_election_model.weighted_yz_test_pred = rng.normal(scale=s, size=(n, 1))
 
+    bootstrap_election_model.n_contests = 6 # a through f
+    bootstrap_election_model.get_aggregate_predictions(reporting_units, nonreporting_units, unexpected_units, ['postal_code'], "margin")
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], 0.95, None, None
     )
@@ -901,6 +905,8 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert all(lower <= upper)
 
     # test with more complicated aggregate
+    bootstrap_election_model.n_contests = 8 # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
+    bootstrap_election_model.get_aggregate_predictions(reporting_units, nonreporting_units, unexpected_units, ['postal_code', 'district'], "margin")
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], 0.95, None, None
     )
@@ -920,6 +926,7 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     s = 2.0
     B = 20
     bootstrap_election_model.B = B
+    bootstrap_election_model.aggregate_pred_margin = rng.normal(scale=s, size=(n, 1))
     bootstrap_election_model.aggregate_error_B_1 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_2 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_3 = rng.normal(scale=s, size=(n, B))
@@ -929,6 +936,7 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
 
     bootstrap_election_model.aggregate_perc_margin_total = rng.normal(scale=s, size=(n, 1))
 
+    
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
     assert "margin" in nat_sum_estimates
     assert len(nat_sum_estimates["margin"]) == 3
@@ -938,9 +946,9 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     # testing adding to base
     base_to_add = rng.random()
     nat_sum_estimates_w_base = bootstrap_election_model.get_national_summary_estimates(None, base_to_add, 0.95)
-    assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(nat_sum_estimates["margin"][0] + base_to_add)
-    assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(nat_sum_estimates["margin"][1] + base_to_add)
-    assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(nat_sum_estimates["margin"][2] + base_to_add)
+    assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(round(nat_sum_estimates["margin"][0] + base_to_add), 2)
+    assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(round(nat_sum_estimates["margin"][1] + base_to_add), 2)
+    assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(round(nat_sum_estimates["margin"][2] + base_to_add), 2)
 
     nat_sum_data_dict = {i: 3 for i in range(n)}
     nat_sum_data_dict[1] = 7

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -1266,13 +1266,13 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     base_to_add = rng.random()
     nat_sum_estimates_w_base = bootstrap_election_model.get_national_summary_estimates(None, base_to_add, 0.95)
     assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(
-        round(nat_sum_estimates["margin"][0] + base_to_add), 2
+        round(nat_sum_estimates["margin"][0] + base_to_add, 2)
     )
     assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(
-        round(nat_sum_estimates["margin"][1] + base_to_add), 2
+        round(nat_sum_estimates["margin"][1] + base_to_add, 2)
     )
     assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(
-        round(nat_sum_estimates["margin"][2] + base_to_add), 2
+        round(nat_sum_estimates["margin"][2] + base_to_add, 2)
     )
 
     nat_sum_data_dict = {i: 3 for i in range(n)}

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -763,19 +763,33 @@ def test_aggregate_predictions(bootstrap_election_model):
     # test with a race call
     called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
-        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin", called_contests=called_contests
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code"],
+        "margin",
+        called_contests=called_contests,
     )
     assert (aggregate_predictions.pred_margin >= bootstrap_election_model.lhs_called_threshold).all()
-    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold # since otherwise would be negative
-    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(0.9 / 2) # should not have changed
+    assert (
+        aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold
+    )  # since otherwise would be negative
+    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(0.9 / 2)  # should not have changed
 
     called_contests = {x: 0 for x in range(bootstrap_election_model.n_contests)}
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
-        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin", called_contests=called_contests
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code"],
+        "margin",
+        called_contests=called_contests,
     )
     assert (aggregate_predictions.pred_margin <= bootstrap_election_model.rhs_called_threshold).all()
-    assert aggregate_predictions.pred_margin.iloc[0] == pytest.approx(-2.6 / 4) # should not have changed
-    assert aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.rhs_called_threshold # since otherwise positive
+    assert aggregate_predictions.pred_margin.iloc[0] == pytest.approx(-2.6 / 4)  # should not have changed
+    assert (
+        aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.rhs_called_threshold
+    )  # since otherwise positive
 
     # test more complicated z predictions
     bootstrap_election_model.weighted_z_test_pred = np.asarray([2, 3, 1, 1, 1, 1]).reshape(-1, 1)
@@ -851,22 +865,40 @@ def test_aggregate_predictions(bootstrap_election_model):
     # test with a race call
     called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
-        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin", called_contests=called_contests
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code", "district"],
+        "margin",
+        called_contests=called_contests,
     )
     assert (aggregate_predictions.pred_margin >= bootstrap_election_model.lhs_called_threshold).all()
-    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold # since otherwise would be zero
-    assert aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.lhs_called_threshold # since otherwise would be negative
-    assert aggregate_predictions.pred_margin.iloc[2] == pytest.approx(0.9 / 2) # should not have changed
-
+    assert (
+        aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold
+    )  # since otherwise would be zero
+    assert (
+        aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.lhs_called_threshold
+    )  # since otherwise would be negative
+    assert aggregate_predictions.pred_margin.iloc[2] == pytest.approx(0.9 / 2)  # should not have changed
 
     called_contests = {x: 0 for x in range(bootstrap_election_model.n_contests)}
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
-        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin", called_contests=called_contests
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code", "district"],
+        "margin",
+        called_contests=called_contests,
     )
     assert (aggregate_predictions.pred_margin <= bootstrap_election_model.rhs_called_threshold).all()
-    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.rhs_called_threshold # since otherwise would be zero
-    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(-2.6 / 3) # should not have changed
-    assert aggregate_predictions.pred_margin.iloc[2] == bootstrap_election_model.rhs_called_threshold # since otherwise would be greater than zero
+    assert (
+        aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.rhs_called_threshold
+    )  # since otherwise would be zero
+    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(-2.6 / 3)  # should not have changed
+    assert (
+        aggregate_predictions.pred_margin.iloc[2] == bootstrap_election_model.rhs_called_threshold
+    )  # since otherwise would be greater than zero
+
 
 def test_get_quantile(bootstrap_election_model):
     bootstrap_election_model.B = 1000

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -924,9 +924,12 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     bootstrap_election_model.aggregate_error_B_2 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_3 = rng.normal(scale=s, size=(n, B))
     bootstrap_election_model.aggregate_error_B_4 = rng.normal(scale=s, size=(n, B))
+    bootstrap_election_model.divided_error_B_1 = np.nan_to_num(bootstrap_election_model.aggregate_error_B_1 / bootstrap_election_model.aggregate_error_B_3)
+    bootstrap_election_model.divided_error_B_2 = np.nan_to_num(bootstrap_election_model.aggregate_error_B_2 / bootstrap_election_model.aggregate_error_B_4)
+
     bootstrap_election_model.aggregate_perc_margin_total = rng.normal(scale=s, size=(n, 1))
 
-    nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, None, 0, 0.95)
+    nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
     assert "margin" in nat_sum_estimates
     assert len(nat_sum_estimates["margin"]) == 3
     assert nat_sum_estimates["margin"][0] >= nat_sum_estimates["margin"][1]
@@ -934,50 +937,19 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
 
     # testing adding to base
     base_to_add = rng.random()
-    nat_sum_estimates_w_base = bootstrap_election_model.get_national_summary_estimates(None, None, base_to_add, 0.95)
+    nat_sum_estimates_w_base = bootstrap_election_model.get_national_summary_estimates(None, base_to_add, 0.95)
     assert nat_sum_estimates_w_base["margin"][0] == pytest.approx(nat_sum_estimates["margin"][0] + base_to_add)
     assert nat_sum_estimates_w_base["margin"][1] == pytest.approx(nat_sum_estimates["margin"][1] + base_to_add)
     assert nat_sum_estimates_w_base["margin"][2] == pytest.approx(nat_sum_estimates["margin"][2] + base_to_add)
 
-    # test calling races
-    states_called = {i: 1 for i in range(n)}
     nat_sum_data_dict = {i: 3 for i in range(n)}
     nat_sum_data_dict[1] = 7
-    nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-        nat_sum_data_dict, states_called, 0, 0.95
-    )
-    assert nat_sum_estimates["margin"][0] == pytest.approx(34)
-    assert nat_sum_estimates["margin"][1] == pytest.approx(34)
-    assert nat_sum_estimates["margin"][2] == pytest.approx(34)
 
-    states_called = {i: 0 for i in range(n)}
-    nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-        nat_sum_data_dict, states_called, 0, 0.95
-    )
-    assert nat_sum_estimates["margin"][0] == pytest.approx(0)
-    assert nat_sum_estimates["margin"][1] == pytest.approx(0)
-    assert nat_sum_estimates["margin"][2] == pytest.approx(0)
-
-    states_called = {i: 0 for i in range(n)}
-    states_called[1] = 1
-    nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-        nat_sum_data_dict, states_called, 0, 0.95
-    )
-    assert nat_sum_estimates["margin"][0] == pytest.approx(7)
-    assert nat_sum_estimates["margin"][1] == pytest.approx(7)
-    assert nat_sum_estimates["margin"][2] == pytest.approx(7)
-
-    # test exceptions
-    states_called = {i: 0 for i in range(n - 1)}
-    with pytest.raises(BootstrapElectionModelException):
-        nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-            nat_sum_data_dict, states_called, 0, 0.95
-        )
-
+    # test exception
     nat_sum_data_dict = {i: 3 for i in range(n - 1)}
     with pytest.raises(BootstrapElectionModelException):
         nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(
-            nat_sum_data_dict, states_called, 0, 0.95
+            nat_sum_data_dict, 0, 0.95
         )
 
 

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -712,6 +712,7 @@ def test_aggregate_predictions(bootstrap_election_model):
             "district",
         ],
     )
+
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
     # test that is top level aggregate is working
@@ -758,6 +759,23 @@ def test_aggregate_predictions(bootstrap_election_model):
     assert aggregate_predictions[aggregate_predictions.postal_code == "d"].reporting[3] == pytest.approx(0)
     assert aggregate_predictions[aggregate_predictions.postal_code == "e"].reporting[4] == pytest.approx(0)
     assert aggregate_predictions[aggregate_predictions.postal_code == "f"].reporting[5] == pytest.approx(0)
+
+    # test with a race call
+    called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}
+    aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin", called_contests=called_contests
+    )
+    assert (aggregate_predictions.pred_margin >= bootstrap_election_model.lhs_called_threshold).all()
+    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold # since otherwise would be negative
+    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(0.9 / 2) # should not have changed
+
+    called_contests = {x: 0 for x in range(bootstrap_election_model.n_contests)}
+    aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin", called_contests=called_contests
+    )
+    assert (aggregate_predictions.pred_margin <= bootstrap_election_model.rhs_called_threshold).all()
+    assert aggregate_predictions.pred_margin.iloc[0] == pytest.approx(-2.6 / 4) # should not have changed
+    assert aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.rhs_called_threshold # since otherwise positive
 
     # test more complicated z predictions
     bootstrap_election_model.weighted_z_test_pred = np.asarray([2, 3, 1, 1, 1, 1]).reshape(-1, 1)
@@ -833,9 +851,22 @@ def test_aggregate_predictions(bootstrap_election_model):
     # test with a race call
     called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
-        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin", called_contests
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin", called_contests=called_contests
     )
-    assert (aggregate_predictions.pred_margin > bootstrap_election_model.lhs_called_threshold).all()
+    assert (aggregate_predictions.pred_margin >= bootstrap_election_model.lhs_called_threshold).all()
+    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.lhs_called_threshold # since otherwise would be zero
+    assert aggregate_predictions.pred_margin.iloc[1] == bootstrap_election_model.lhs_called_threshold # since otherwise would be negative
+    assert aggregate_predictions.pred_margin.iloc[2] == pytest.approx(0.9 / 2) # should not have changed
+
+
+    called_contests = {x: 0 for x in range(bootstrap_election_model.n_contests)}
+    aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
+        reporting_units, nonreporting_units, unexpected_units, ["postal_code", "district"], "margin", called_contests=called_contests
+    )
+    assert (aggregate_predictions.pred_margin <= bootstrap_election_model.rhs_called_threshold).all()
+    assert aggregate_predictions.pred_margin.iloc[0] == bootstrap_election_model.rhs_called_threshold # since otherwise would be zero
+    assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(-2.6 / 3) # should not have changed
+    assert aggregate_predictions.pred_margin.iloc[2] == bootstrap_election_model.rhs_called_threshold # since otherwise would be greater than zero
 
 def test_get_quantile(bootstrap_election_model):
     bootstrap_election_model.B = 1000


### PR DESCRIPTION
## Description
We move the race calling from `get_national_summary` to `get_aggregate_predictions` and `get_aggregate_prediction_intervals`. This means that we apply the race calls to the contest level predictions also (ie. state predictions or house district predictions) instead of purely on the national summary predictions. 

This is more conceptually correct, but will also let us show the our contest level predictions after race calls have already happened if we want.

Unit tests were also updated to take this into account.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-4455

## Test Steps
```
elexmodel 2017-11-07_VA_G --estimands=margin --office_id=G --geographic_unit_type=county --pi_method bootstrap --features baseline_normalized_margin --called_contests='{"VA": 0}' --percent_reporting 10 --aggregates postal_code --aggregates county_classification
```
This now allows a force call for Republicans (and you can see the predictions and intervals all be below zero for the state as a result). 

If you want to test on aggregate model, then you can just add more contests using this dictionary (either in the CLI or using the testbed).
```
{'VA-47': 0, 'VA-50': 0, 'VA-51': 0, 'VA-53': 0, 'VA-55': 1, 'VA-61': 0, 'VA-62': 0, 'VA-89': 0, 'VA-64': 0, 'VA-65': 1, 'VA-66': 0, 'VA-70': 1, 'VA-71': 0, 'VA-73': 0, 'VA-75': 0, 'VA-82': -1, 'VA-60': 0, 'VA-76': 1, 'VA-83': 0, 'VA-84': 1, 'VA-41': -1, 'VA-33': 0, 'VA-86': 0, 'VA-87': 1, 'VA-88': 1, 'VA-90': 0, 'VA-93': 1, 'VA-94': 1, 'VA-96': 1, 'VA-34': 0, 'VA-97': 1, 'VA-99': 0, 'VA-72': 0, 'VA-31': 0, 'VA-11': 1, 'VA-30': 0, 'VA-52': 0, 'VA-91': 1, 'VA-92': 1, 'VA-100': 0, 'VA-6': 1, 'VA-7': 1, 'VA-8': 1, 'VA-9': 1, 'VA-10': 1, 'VA-14': 1, 'VA-15': 1, 'VA-18': 1, 'VA-21': -1, 'VA-32': 0, 'VA-36': 0, 'VA-37': 0, 'VA-40': 0, 'VA-57': 0, 'VA-58': 1, 'VA-59': 0, 'VA-23': 1, 'VA-20': 1, 'VA-22': 0, 'VA-25': 1, 'VA-26': 1, 'VA-27': 1, 'VA-28': 1, 'VA-29': 1, 'VA-67': 0}
```

also `pytest`