### PR TITLE
replace point pred with bootstrap mean

### DIFF
--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -968,7 +968,6 @@ class BootstrapElectionModel(BaseElectionModel):
         z_test_pred = (ols_z.predict(x_test) + (aggregate_indicator_test @ epsilon_z_hat)).clip(
             min=z_partial_reporting_lower, max=z_partial_reporting_upper
         )
-        yz_test_pred = y_test_pred * z_test_pred
 
         # we now need to generate our bootstrapped "true" quantities (in order to subtract the
         # bootstrapped estimates from these quantities to get an estimate for our error)
@@ -1017,10 +1016,11 @@ class BootstrapElectionModel(BaseElectionModel):
             min=z_partial_reporting_lower, max=z_partial_reporting_upper
         ) * weights_test
 
+        # the point prediction is the bootstrap sample mean
         # this is for the unit point prediction. turn into unnormalized margin
-        self.weighted_yz_test_pred = yz_test_pred * weights_test
+        self.weighted_yz_test_pred = yz_test_pred_B.mean(axis=1).reshape(-1, 1) * weights_test
         # and turn into turnout estimate
-        self.weighted_z_test_pred = z_test_pred * weights_test
+        self.weighted_z_test_pred = z_test_pred_B.mean(axis=1).reshape(-1, 1) * weights_test
         self.ran_bootstrap = True
 
     def get_unit_predictions(

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -960,14 +960,12 @@ class BootstrapElectionModel(BaseElectionModel):
         # \tilde{y_i}^{b} * \tilde{z_i}^{b}
         yz_test_pred_B = y_test_pred_B * z_test_pred_B
 
-        # In order to generate our point prediction, we also need to apply our non-bootstrapped model to the testset
+        # In order to generate our point prediction, we take the bootstrap mean.
         # this is \hat{y_i} and \hat{z_i}
-        y_test_pred = (ols_y.predict(x_test) + (aggregate_indicator_test @ epsilon_y_hat)).clip(
-            min=y_partial_reporting_lower, max=y_partial_reporting_upper
-        )
-        z_test_pred = (ols_z.predict(x_test) + (aggregate_indicator_test @ epsilon_z_hat)).clip(
-            min=z_partial_reporting_lower, max=z_partial_reporting_upper
-        )
+        y_test_pred = y_test_pred_B.mean(axis=1).reshape(-1, 1)
+        z_test_pred = z_test_pred_B.mean(axis=1).reshape(-1, 1)
+        yz_test_pred = y_test_pred * z_test_pred
+
 
         # we now need to generate our bootstrapped "true" quantities (in order to subtract the
         # bootstrapped estimates from these quantities to get an estimate for our error)
@@ -1016,11 +1014,10 @@ class BootstrapElectionModel(BaseElectionModel):
             min=z_partial_reporting_lower, max=z_partial_reporting_upper
         ) * weights_test
 
-        # the point prediction is the bootstrap sample mean
         # this is for the unit point prediction. turn into unnormalized margin
-        self.weighted_yz_test_pred = yz_test_pred_B.mean(axis=1).reshape(-1, 1) * weights_test
+        self.weighted_yz_test_pred = yz_test_pred * weights_test
         # and turn into turnout estimate
-        self.weighted_z_test_pred = z_test_pred_B.mean(axis=1).reshape(-1, 1) * weights_test
+        self.weighted_z_test_pred = z_test_pred * weights_test
         self.ran_bootstrap = True
 
     def get_unit_predictions(

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -966,7 +966,6 @@ class BootstrapElectionModel(BaseElectionModel):
         z_test_pred = z_test_pred_B.mean(axis=1).reshape(-1, 1)
         yz_test_pred = y_test_pred * z_test_pred
 
-
         # we now need to generate our bootstrapped "true" quantities (in order to subtract the
         # bootstrapped estimates from these quantities to get an estimate for our error)
         # In a normal bootstrap setting we would replace y and z with \hat{y} and \hat{z}


### PR DESCRIPTION
## Description
We are replacing the unit level point prediction with the bootstrap sample mean.

This makes sure that the point prediction is always centered around the average of `error_B_1`, which forces our interval to be the `error_B_2`'s (fake test error) deviation from that. This would make issues around weirdly shaped intervals easier to debug on election night.


## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-4464

## Test Steps
```
elexmodel 2017-11-07_VA_G --estimands=margin --office_id=G --geographic_unit_type=county --pi_method bootstrap --features baseline_normalized_margin --percent_reporting 10 --aggregates postal_code --aggregates county_classification
```