### PR TITLE
ELEX-3468 save unit level turnout prediction from bootstrap model to s3

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -359,7 +359,10 @@ class ModelClient:
             unit_predictions, unit_turnout_predictions = self.model.get_unit_predictions(
                 reporting_units, nonreporting_units, estimand, unexpected_units=unexpected_units
             )
-            self.results_handler.add_unit_predictions(estimand, unit_predictions, unit_turnout_predictions)
+            self.results_handler.add_unit_predictions(estimand, unit_predictions)
+            if unit_turnout_predictions is not None:
+                self.results_handler.add_unit_turnout_predictions(unit_turnout_predictions)
+
             # gets prediciton intervals for each alpha
             alpha_to_unit_prediction_intervals = {}
             for alpha in prediction_intervals:

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -31,7 +31,7 @@ class ModelResultsHandler:
         self.nonreporting_units = nonreporting_units
         self.unexpected_units = unexpected_units
 
-    def add_unit_predictions(self, estimand, unit_predictions, unit_turnout_predictions):
+    def add_unit_predictions(self, estimand, unit_predictions):
         """
         unit_predictions: data frame with unit predictions, as produced by model.get_unit_predictions
 
@@ -40,10 +40,10 @@ class ModelResultsHandler:
         self.nonreporting_units[f"pred_{estimand}"] = unit_predictions
         self.unexpected_units[f"pred_{estimand}"] = self.unexpected_units[f"results_{estimand}"]
 
-        if unit_turnout_predictions is not None:
-            self.reporting_units["pred_turnout"] = self.reporting_units["results_weights"]
-            self.nonreporting_units["pred_turnout"] = unit_turnout_predictions
-            self.unexpected_units["pred_turnout"] = self.unexpected_units["results_weights"]
+    def add_unit_turnout_predictions(self, unit_turnout_predictions):
+        self.reporting_units["pred_turnout"] = self.reporting_units["results_weights"]
+        self.nonreporting_units["pred_turnout"] = unit_turnout_predictions
+        self.unexpected_units["pred_turnout"] = self.unexpected_units["results_weights"]
 
     def add_unit_intervals(self, estimand, prediction_intervals_unit):
         """

--- a/tests/handlers/test_model_results.py
+++ b/tests/handlers/test_model_results.py
@@ -58,13 +58,21 @@ intervals2_e1 = {0.7: PredictionIntervals([3900], [4600]), 0.9: PredictionInterv
 intervals1_e2 = {0.7: PredictionIntervals([400, 1600], [400, 1800]), 0.9: PredictionIntervals([400, 1500], [400, 2000])}
 intervals2_e2 = {0.7: PredictionIntervals([2000], [2200]), 0.9: PredictionIntervals([1800], [2400])}
 
+reporting_with_turnout = reporting.copy().drop(columns=["results_e2"])
+reporting_with_turnout["results_weights"] = [100000, 200000]
+nonreporting_turnout = [0]
+notexpected_with_turnout = notexpected.copy().drop(columns=["results_e2"])
+notexpected_with_turnout["results_weights"] = [0]
+
 
 def test_model_results_handler():
     # test unit predictions/intervals methods for two estimands
-    handler = ModelResultsHandler(["district", "unit", "postal_code"], [0.7, 0.9], reporting, nonreporting, notexpected)
-    handler.add_unit_predictions("e1", predictions_e1, None)
+    handler = ModelResultsHandler(
+        ["district", "unit", "postal_code"], [0.7, 0.9], reporting.copy(), nonreporting.copy(), notexpected.copy()
+    )
+    handler.add_unit_predictions("e1", predictions_e1)
     handler.add_unit_intervals("e1", intervals_e1)
-    handler.add_unit_predictions("e2", predictions_e2, None)
+    handler.add_unit_predictions("e2", predictions_e2)
     handler.add_unit_intervals("e2", intervals_e2)
     expected_cols = [
         "pred_e1",
@@ -105,11 +113,59 @@ def test_model_results_handler():
 
 
 def test_no_unit_data():
-    handler = ModelResultsHandler(["postal_code"], [0.7, 0.9], reporting, nonreporting, notexpected)
-    handler.add_unit_predictions("e1", predictions_e1, None)
+    handler = ModelResultsHandler(
+        ["postal_code"], [0.7, 0.9], reporting.copy(), nonreporting.copy(), notexpected.copy()
+    )
+    handler.add_unit_predictions("e1", predictions_e1)
     handler.add_unit_intervals("e1", intervals_e1)
 
     handler.add_agg_predictions("e1", "postal_code", agg1_e1, intervals1_e1)
     handler.process_final_results()
 
     assert "unit_data" not in handler.final_results
+
+
+def test_add_turnout_results():
+    handler = ModelResultsHandler(
+        ["district", "unit", "postal_code"],
+        [0.7, 0.9],
+        reporting_with_turnout.copy(),
+        nonreporting.copy(),
+        notexpected_with_turnout.copy(),
+    )
+    handler.add_unit_predictions("e1", predictions_e1)
+    handler.add_unit_intervals("e1", intervals_e1)
+    handler.add_unit_turnout_predictions(nonreporting_turnout)
+    expected_cols = [
+        "pred_e1",
+        "lower_0.7_e1",
+        "lower_0.9_e1",
+        "upper_0.7_e1",
+        "upper_0.9_e1",
+        "results_weights",
+        "pred_turnout",
+    ]
+
+    assert set(expected_cols).issubset(set(handler.reporting_units))
+    assert set(expected_cols).difference({"results_weights"}).issubset(set(handler.nonreporting_units))
+    assert set(expected_cols).issubset(set(handler.unexpected_units))
+
+    # # test agg predictions for 2 aggs and 2 estimands
+    # handler.add_agg_predictions("e1", "district", agg1_e1, intervals1_e1)
+    # handler.add_agg_predictions("e1", "postal_code", agg2_e1, intervals2_e1)
+
+    # assert len(handler.estimates["postal_code"]) == 2
+    # assert len(handler.estimates["district"]) == 2
+    # expected_cols_agg = ["pred", "lower_0.7", "lower_0.9", "upper_0.7", "upper_0.9"]
+    # for v in handler.estimates.values():
+    #     for i, df in enumerate(v):
+    #         expected_cols = [f"{x}_e{i+1}" for x in expected_cols_agg]
+    #         assert set(expected_cols).issubset(set(df.columns))
+
+    # # test preparation of final results data
+    # handler.process_final_results()
+
+    # assert set(handler.final_results.keys()) == set(["unit_data", "state_data", "district_data"])
+    # assert len(handler.final_results["unit_data"]) == 4
+    # assert len(handler.final_results["state_data"]) == 1
+    # assert len(handler.final_results["district_data"]) == 2

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -645,7 +645,7 @@ def test_adjust_called_contests(bootstrap_election_model, rng):
     )  # since called for RHS but positive should be repalced
 
 
-def test_aggregate_predictions(bootstrap_election_model):
+def get_data_used_for_testing_aggregate_predictions():
     reporting_units = pd.DataFrame(
         [
             ["a", -3, 0.2, 1, 1, 1, 1, 3, 5, 8, "c"],
@@ -713,6 +713,12 @@ def test_aggregate_predictions(bootstrap_election_model):
         ],
     )
 
+    return (reporting_units, nonreporting_units, unexpected_units)
+
+
+def test_aggregate_predictions_no_race_calls(bootstrap_election_model):
+    (reporting_units, nonreporting_units, unexpected_units) = get_data_used_for_testing_aggregate_predictions()
+    bootstrap_election_model.n_contests = 6  # a through f
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
     # test that is top level aggregate is working
@@ -722,7 +728,6 @@ def test_aggregate_predictions(bootstrap_election_model):
     with pytest.raises(AttributeError):
         bootstrap_election_model.aggregate_baseline_margin
 
-    bootstrap_election_model.n_contests = 6  # a through f
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
     )
@@ -759,6 +764,12 @@ def test_aggregate_predictions(bootstrap_election_model):
     assert aggregate_predictions[aggregate_predictions.postal_code == "d"].reporting[3] == pytest.approx(0)
     assert aggregate_predictions[aggregate_predictions.postal_code == "e"].reporting[4] == pytest.approx(0)
     assert aggregate_predictions[aggregate_predictions.postal_code == "f"].reporting[5] == pytest.approx(0)
+
+
+def test_aggregate_predictions_with_race_call(bootstrap_election_model):
+    (reporting_units, nonreporting_units, unexpected_units) = get_data_used_for_testing_aggregate_predictions()
+    bootstrap_election_model.n_contests = 6  # a through f
+    bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
     # test with a race call
     called_contests = {x: 1 for x in range(bootstrap_election_model.n_contests)}

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -731,39 +731,38 @@ def test_aggregate_predictions_no_race_calls(bootstrap_election_model):
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin"
     )
+    aggregate_predictions = aggregate_predictions.set_index("postal_code")
 
     assert bootstrap_election_model.aggregate_baseline_margin is not None
 
-    assert aggregate_predictions[aggregate_predictions.postal_code == "a"].pred_margin[0] == pytest.approx(
-        -2.6 / 4
-    )  # (-3 (pred) + 0.2 + 0 (reporting margin) + 0.2 (unexpected margin))/ 4
-    assert aggregate_predictions[aggregate_predictions.postal_code == "b"].pred_margin[1] == pytest.approx(
-        0.9 / 2
-    )  # (-0.1 + 1) / 2
-    assert aggregate_predictions[aggregate_predictions.postal_code == "c"].pred_margin[2] == pytest.approx(
-        0.3
-    )  # (0.3 + 0.3) / 2
-    assert aggregate_predictions[aggregate_predictions.postal_code == "d"].pred_margin[3] == pytest.approx(
-        8 / 3
-    )  # 0.8 / 3
-    assert aggregate_predictions[aggregate_predictions.postal_code == "e"].pred_margin[4] == pytest.approx(
-        4
-    )  # (4 + 4) / 2
-    assert aggregate_predictions[aggregate_predictions.postal_code == "f"].pred_margin[5] == pytest.approx(0.7 / 2)
+    # (-3 (pred) + 0.2 + 0 (reporting margin) + 0.2 (unexpected margin))/ 4
+    assert aggregate_predictions.loc["a", "pred_margin"] == pytest.approx(-2.6 / 4)
+    assert aggregate_predictions.loc["b", "pred_margin"] == pytest.approx(0.9 / 2)  # (-0.1 + 1) / 2
+    assert aggregate_predictions.loc["c", "pred_margin"] == pytest.approx(0.3)  # (0.3 + 0.3) / 2
+    assert aggregate_predictions.loc["d", "pred_margin"] == pytest.approx(8 / 3)  # 0.8 / 3
+    assert aggregate_predictions.loc["e", "pred_margin"] == pytest.approx(4)  # (4 + 4) / 2
+    assert aggregate_predictions.loc["f", "pred_margin"] == pytest.approx(0.7 / 2)
 
-    assert aggregate_predictions[aggregate_predictions.postal_code == "a"].results_margin[0] == pytest.approx(0.6 / 4)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "b"].results_margin[1] == pytest.approx(-0.1 / 2)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "c"].results_margin[2] == pytest.approx(0.3)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "d"].results_margin[3] == pytest.approx(0.7 / 3)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "e"].results_margin[4] == pytest.approx(0.1)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "f"].results_margin[5] == pytest.approx(0.7 / 2)
+    assert aggregate_predictions.loc["a", "results_margin"] == pytest.approx(0.6 / 4)
+    assert aggregate_predictions.loc["b", "results_margin"] == pytest.approx(-0.1 / 2)
+    assert aggregate_predictions.loc["c", "results_margin"] == pytest.approx(0.3)
+    assert aggregate_predictions.loc["d", "results_margin"] == pytest.approx(0.7 / 3)
+    assert aggregate_predictions.loc["e", "results_margin"] == pytest.approx(0.1)
+    assert aggregate_predictions.loc["f", "results_margin"] == pytest.approx(0.7 / 2)
 
-    assert aggregate_predictions[aggregate_predictions.postal_code == "a"].reporting[0] == pytest.approx(2)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "b"].reporting[1] == pytest.approx(1)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "c"].reporting[2] == pytest.approx(2)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "d"].reporting[3] == pytest.approx(0)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "e"].reporting[4] == pytest.approx(0)
-    assert aggregate_predictions[aggregate_predictions.postal_code == "f"].reporting[5] == pytest.approx(0)
+    assert aggregate_predictions.loc["a", "reporting"] == pytest.approx(2)
+    assert aggregate_predictions.loc["b", "reporting"] == pytest.approx(1)
+    assert aggregate_predictions.loc["c", "reporting"] == pytest.approx(2)
+    assert aggregate_predictions.loc["d", "reporting"] == pytest.approx(0)
+    assert aggregate_predictions.loc["e", "reporting"] == pytest.approx(0)
+    assert aggregate_predictions.loc["f", "reporting"] == pytest.approx(0)
+
+    assert aggregate_predictions.loc["a", "pred_turnout"] == pytest.approx(4)
+    assert aggregate_predictions.loc["b", "pred_turnout"] == pytest.approx(2)
+    assert aggregate_predictions.loc["c", "pred_turnout"] == pytest.approx(2)
+    assert aggregate_predictions.loc["d", "pred_turnout"] == pytest.approx(3)
+    assert aggregate_predictions.loc["e", "pred_turnout"] == pytest.approx(2)
+    assert aggregate_predictions.loc["f", "pred_turnout"] == pytest.approx(2)
 
 
 def test_aggregate_predictions_with_race_call(bootstrap_election_model):

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -813,6 +813,10 @@ def test_aggregate_predictions_with_race_call(bootstrap_election_model):
     )  # now divided by 5 since the a in non reporting has weight 2
     assert aggregate_predictions[aggregate_predictions.postal_code == "b"].pred_margin[1] == pytest.approx(0.9 / 4)
 
+
+def test_more_complicated_aggregate_predictions_with_race_call(bootstrap_election_model):
+    (reporting_units, nonreporting_units, unexpected_units) = get_data_used_for_testing_aggregate_predictions()
+
     # test more complicated aggregate (postal code-district)
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
     bootstrap_election_model.n_contests = 8  # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)


### PR DESCRIPTION
## Description

Hi!  The changes in this PR:

* refactor some of the code around making sure `pred_turnout` is in the unit predictions/reporting `ModelResults`;
* output aggregated `pred_turnout` per aggregate (e.g. "district") in the predictions;
* provide unit tests for both (with some refactoring)

Please let me know what you think and if this is what you're looking for 😬 

## Jira Ticket

[ELEX-3468]

## Test Steps

`tox` and an `elexmodel` command with `--save_output results` such as:

```
elexmodel 2022-11-08_USA_G --estimands=margin --features=baseline_normalized_margin --office_id=G_county --geographic_unit_type=county --pi_method bootstrap --national_summary --save_output results
```

Confirm in the s3 bucket under `unit_data/` and each aggregate (except `nat_sum_data/`) that `pred_turnout` now appears in every CSV 🎉 

[ELEX-3468]: https://arcpublishing.atlassian.net/browse/ELEX-3468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ