### PR TITLE
ELEX-3394 Part 1: distinguish between unexpected and non-predictive units

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -325,9 +325,9 @@ class ModelClient:
         if APP_ENV != "local" and self.save_results:
             data.write_data(self.election_id, self.office)
 
-        non_predictive_units = unexpected_units[~unexpected_units["predictive"]]
+        non_predictive_units = unexpected_units[unexpected_units["unit_category"] == "non-modeled"]
         n_reporting_expected_units = reporting_units.shape[0]
-        n_unexpected_units = len(unexpected_units[unexpected_units["predictive"]])
+        n_unexpected_units = len(unexpected_units[unexpected_units["unit_category"] == "unexpected"])
         n_nonreporting_units = nonreporting_units.shape[0]
         n_non_predictive_units = len(non_predictive_units)
         LOG.info(

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -301,7 +301,7 @@ class ModelClient:
         nonreporting_units = data.get_nonreporting_units(
             percent_reporting_threshold, turnout_factor_lower, turnout_factor_upper
         )
-        unexpected_units = data.get_unexpected_units(
+        (unexpected_units, non_predictive_units) = data.get_unexpected_units(
             percent_reporting_threshold, aggregates, turnout_factor_lower, turnout_factor_upper
         )
 
@@ -334,10 +334,12 @@ class ModelClient:
         n_reporting_expected_units = reporting_units.shape[0]
         n_unexpected_units = unexpected_units.shape[0]
         n_nonreporting_units = nonreporting_units.shape[0]
+        n_non_predictive_units = non_predictive_units.shape[0]
         LOG.info(
             f"""Running model
             There are {n_reporting_expected_units} reporting and expected units.
             There are {n_unexpected_units} unexpected units.
+            There are {n_non_predictive_units} non-predictive units.
             There are {n_nonreporting_units} nonreporting units."""
         )
 
@@ -350,6 +352,8 @@ class ModelClient:
         duplicate_units = units_by_count[units_by_count > 1].to_dict()
         if len(duplicate_units) > 0:
             raise ModelClientException(f"At least one unit appears twice: {duplicate_units}")
+
+        unexpected_units = pd.concat([unexpected_units, non_predictive_units], ignore_index=True)
 
         self.results_handler = ModelResultsHandler(
             aggregates, prediction_intervals, reporting_units, nonreporting_units, unexpected_units

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -325,10 +325,11 @@ class ModelClient:
         if APP_ENV != "local" and self.save_results:
             data.write_data(self.election_id, self.office)
 
+        non_predictive_units = unexpected_units[~unexpected_units["predictive"]]
         n_reporting_expected_units = reporting_units.shape[0]
         n_unexpected_units = len(unexpected_units[unexpected_units["predictive"]])
         n_nonreporting_units = nonreporting_units.shape[0]
-        n_non_predictive_units = len(unexpected_units[~unexpected_units["predictive"]])
+        n_non_predictive_units = len(non_predictive_units)
         LOG.info(
             f"""Running model
             There are {n_reporting_expected_units} reporting and expected units.
@@ -336,6 +337,11 @@ class ModelClient:
             There are {n_non_predictive_units} non-predictive units.
             There are {n_nonreporting_units} nonreporting units."""
         )
+        if len(non_predictive_units) > 0:
+            non_predictive_units = (
+                non_predictive_units.groupby("postal_code")["geographic_unit_fips"].apply(list).to_dict()
+            )
+            LOG.info(f"non-predictive units:\n{non_predictive_units}")
 
         if n_reporting_expected_units < minimum_reporting_units_max:
             raise ModelNotEnoughSubunitsException(

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -325,23 +325,21 @@ class ModelClient:
         if APP_ENV != "local" and self.save_results:
             data.write_data(self.election_id, self.office)
 
-        non_predictive_units = unexpected_units[unexpected_units["unit_category"] == "non-modeled"]
+        non_modeled_units = unexpected_units[unexpected_units["unit_category"] == "non-modeled"]
         n_reporting_expected_units = reporting_units.shape[0]
         n_unexpected_units = len(unexpected_units[unexpected_units["unit_category"] == "unexpected"])
         n_nonreporting_units = nonreporting_units.shape[0]
-        n_non_predictive_units = len(non_predictive_units)
+        n_non_modeled_units = len(non_modeled_units)
         LOG.info(
             f"""Running model
             There are {n_reporting_expected_units} reporting and expected units.
             There are {n_unexpected_units} unexpected units.
-            There are {n_non_predictive_units} non-predictive units.
+            There are {n_non_modeled_units} non-modeled units.
             There are {n_nonreporting_units} nonreporting units."""
         )
-        if len(non_predictive_units) > 0:
-            non_predictive_units = (
-                non_predictive_units.groupby("postal_code")["geographic_unit_fips"].apply(list).to_dict()
-            )
-            LOG.info(f"non-predictive units:\n{non_predictive_units}")
+        if len(non_modeled_units) > 0:
+            non_modeled_units = non_modeled_units.groupby("postal_code")["geographic_unit_fips"].apply(list).to_dict()
+            LOG.info(f"non-modeled units:\n{non_modeled_units}")
 
         if n_reporting_expected_units < minimum_reporting_units_max:
             raise ModelNotEnoughSubunitsException(

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -326,13 +326,14 @@ class ModelClient:
             data.write_data(self.election_id, self.office)
 
         n_reporting_expected_units = reporting_units.shape[0]
-        n_unexpected_units = unexpected_units.shape[0]
+        n_unexpected_units = len(unexpected_units[unexpected_units["predictive"]])
         n_nonreporting_units = nonreporting_units.shape[0]
-        # n_non_predictive_units = non_predictive_units.shape[0]
+        n_non_predictive_units = len(unexpected_units[~unexpected_units["predictive"]])
         LOG.info(
             f"""Running model
             There are {n_reporting_expected_units} reporting and expected units.
             There are {n_unexpected_units} unexpected units.
+            There are {n_non_predictive_units} non-predictive units.
             There are {n_nonreporting_units} nonreporting units."""
         )
 
@@ -345,8 +346,6 @@ class ModelClient:
         duplicate_units = units_by_count[units_by_count > 1].to_dict()
         if len(duplicate_units) > 0:
             raise ModelClientException(f"At least one unit appears twice: {duplicate_units}")
-
-        # unexpected_units = pd.concat([unexpected_units, non_predictive_units], ignore_index=True)
 
         self.results_handler = ModelResultsHandler(
             aggregates, prediction_intervals, reporting_units, nonreporting_units, unexpected_units

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -295,14 +295,8 @@ class ModelClient:
         turnout_factor_lower = model_parameters.get("turnout_factor_lower", 0.2)
         turnout_factor_upper = model_parameters.get("turnout_factor_upper", 2.5)
 
-        reporting_units = data.get_reporting_units(
-            percent_reporting_threshold, turnout_factor_lower, turnout_factor_upper
-        )
-        nonreporting_units = data.get_nonreporting_units(
-            percent_reporting_threshold, turnout_factor_lower, turnout_factor_upper
-        )
-        (unexpected_units, non_predictive_units) = data.get_unexpected_units(
-            percent_reporting_threshold, aggregates, turnout_factor_lower, turnout_factor_upper
+        (reporting_units, nonreporting_units, unexpected_units) = data.get_units(
+            percent_reporting_threshold, turnout_factor_lower, turnout_factor_upper, aggregates
         )
 
         LOG.info(
@@ -334,12 +328,11 @@ class ModelClient:
         n_reporting_expected_units = reporting_units.shape[0]
         n_unexpected_units = unexpected_units.shape[0]
         n_nonreporting_units = nonreporting_units.shape[0]
-        n_non_predictive_units = non_predictive_units.shape[0]
+        # n_non_predictive_units = non_predictive_units.shape[0]
         LOG.info(
             f"""Running model
             There are {n_reporting_expected_units} reporting and expected units.
             There are {n_unexpected_units} unexpected units.
-            There are {n_non_predictive_units} non-predictive units.
             There are {n_nonreporting_units} nonreporting units."""
         )
 
@@ -353,7 +346,7 @@ class ModelClient:
         if len(duplicate_units) > 0:
             raise ModelClientException(f"At least one unit appears twice: {duplicate_units}")
 
-        unexpected_units = pd.concat([unexpected_units, non_predictive_units], ignore_index=True)
+        # unexpected_units = pd.concat([unexpected_units, non_predictive_units], ignore_index=True)
 
         self.results_handler = ModelResultsHandler(
             aggregates, prediction_intervals, reporting_units, nonreporting_units, unexpected_units

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -84,7 +84,7 @@ class CombinedDataHandler:
             ) / reporting_units[f"last_election_results_{estimand}"]
 
         reporting_units["reporting"] = int(1)
-        reporting_units["expected"] = True
+        reporting_units["unit_category"] = "reporting"
 
         # units where expected vote is less than the percent reporting threshold
         nonreporting_units = self.data[self.data.percent_expected_vote < percent_reporting_threshold].reset_index(
@@ -100,11 +100,12 @@ class CombinedDataHandler:
         ].reset_index(drop=True)
 
         nonreporting_units["reporting"] = int(0)
-        nonreporting_units["expected"] = True
+        nonreporting_units["unit_category"] = "non-reporting"
 
         # finalize all unexpected/non-predictive units
-        unexpected_units["predictive"] = True
-        non_predictive_units["predictive"] = False
+        unexpected_units["unit_category"] = "unexpected"
+        non_predictive_units["unit_category"] = "non-modeled"
+
         all_unexpected_units = pd.concat([unexpected_units, non_predictive_units]).reset_index(drop=True)
         # since we were not expecting them, we have don't have their county or district
         # from preprocessed data. so we have to add that back in.
@@ -118,7 +119,6 @@ class CombinedDataHandler:
             )
 
         all_unexpected_units["reporting"] = int(0)
-        all_unexpected_units["expected"] = False
 
         return (reporting_units, nonreporting_units, all_unexpected_units)
 

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -103,6 +103,8 @@ class CombinedDataHandler:
         nonreporting_units["expected"] = True
 
         # finalize all unexpected/non-predictive units
+        unexpected_units["predictive"] = True
+        non_predictive_units["predictive"] = False
         all_unexpected_units = pd.concat([unexpected_units, non_predictive_units]).reset_index(drop=True)
         # since we were not expecting them, we have don't have their county or district
         # from preprocessed data. so we have to add that back in.

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -85,7 +85,7 @@ class CombinedDataHandler:
             ) / reporting_units[f"last_election_results_{estimand}"]
 
         reporting_units["reporting"] = int(1)
-        reporting_units["unit_category"] = "reporting"
+        reporting_units["unit_category"] = "expected"
 
         # units where expected vote is less than the percent reporting threshold
         nonreporting_units = self.data[self.data.percent_expected_vote < percent_reporting_threshold].reset_index(
@@ -101,7 +101,7 @@ class CombinedDataHandler:
         ].reset_index(drop=True)
 
         nonreporting_units["reporting"] = int(0)
-        nonreporting_units["unit_category"] = "non-reporting"
+        nonreporting_units["unit_category"] = "expected"
 
         # finalize all unexpected/non-modeled units
         unexpected_units["unit_category"] = "unexpected"

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -104,7 +104,7 @@ class Featurizer:
                 if x.startswith(tuple(fixed_effect + "_" for fixed_effect in self.fixed_effect_cols))
             ]
 
-            df_fitting = df[(df.reporting) & (df.expected)]
+            df_fitting = df.query('reporting & unit_category == "reporting"')
             # get the indices of all expanded fixed effects in the fitting data
             # (active fixed effects + the fixed effect we will drop for multicolinearity)
             active_fixed_effect_boolean_df = df_fitting[all_expanded_fixed_effects].sum(axis=0) > 0

--- a/src/elexmodel/handlers/data/Featurizer.py
+++ b/src/elexmodel/handlers/data/Featurizer.py
@@ -104,7 +104,7 @@ class Featurizer:
                 if x.startswith(tuple(fixed_effect + "_" for fixed_effect in self.fixed_effect_cols))
             ]
 
-            df_fitting = df.query('reporting & unit_category == "reporting"')
+            df_fitting = df[(df.reporting) & (df.unit_category == "expected")]
             # get the indices of all expanded fixed effects in the fitting data
             # (active fixed effects + the fixed effect we will drop for multicolinearity)
             active_fixed_effect_boolean_df = df_fitting[all_expanded_fixed_effects].sum(axis=0) > 0

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -66,7 +66,7 @@ class ModelResultsHandler:
         self.unit_data[estimand] = pd.concat(
             [self.reporting_units, self.nonreporting_units, self.unexpected_units]
         ).sort_values("geographic_unit_fips")[
-            ["postal_code", "geographic_unit_fips", f"pred_{estimand}", "reporting"]
+            ["postal_code", "geographic_unit_fips", f"pred_{estimand}", "reporting", "unit_category"]
             + interval_cols
             + [f"results_{estimand}"]
             + (["pred_turnout"] if estimand == "margin" else [])
@@ -104,13 +104,6 @@ class ModelResultsHandler:
             # joins together unit data dfs (for different estimands)
             self.final_results["unit_data"] = reduce(
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
-            )
-            self.final_results["unit_data"] = self.final_results["unit_data"].merge(
-                pd.concat([self.reporting_units, self.nonreporting_units, self.unexpected_units], ignore_index=True)[
-                    ["geographic_unit_fips", "unit_category"]
-                ],
-                on=["geographic_unit_fips"],
-                how="left",
             )
 
     def add_national_summary_estimates(self, national_summary_dict):

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -105,6 +105,13 @@ class ModelResultsHandler:
             self.final_results["unit_data"] = reduce(
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
             )
+            self.final_results["unit_data"] = self.final_results["unit_data"].merge(
+                pd.concat([self.reporting_units, self.nonreporting_units, self.unexpected_units], ignore_index=True)[
+                    ["geographic_unit_fips", "unit_category"]
+                ],
+                on=["geographic_unit_fips"],
+                how="left",
+            )
 
     def add_national_summary_estimates(self, national_summary_dict):
         df = pd.DataFrame.from_dict(

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -250,7 +250,8 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
     assert unexpected_data["county_fips"].map(lambda x: len(x) == 6).all()
     assert unexpected_data[unexpected_data.district == ""].shape[0] == 0
     assert unexpected_data["district"].map(lambda x: len(x) < 6).all()
-    assert len(unexpected_data[unexpected_data["predictive"]]) == unexpected_units
+    # no non-predictive units here
+    assert len(unexpected_data[unexpected_data["unit_category"] == "unexpected"]) == unexpected_units
 
 
 def test_get_unexpected_units_county(va_governor_county_data):
@@ -289,7 +290,8 @@ def test_get_unexpected_units_county(va_governor_county_data):
     assert unexpected_data["county_fips"].map(lambda x: len(x) == 6).all()
     # test that nonreporting unexpected unit is captured here
     assert unexpected_data[unexpected_data.percent_expected_vote == 50].shape[0] == 1
-    assert len(unexpected_data[unexpected_data["predictive"]]) == reporting_unexpected_units + 1
+    # no non-predictive units here
+    assert len(unexpected_data[unexpected_data["unit_category"] == "unexpected"]) == reporting_unexpected_units + 1
 
 
 def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
@@ -316,7 +318,7 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
 
     assert va_governor_county_data.loc[0].geographic_unit_fips in unexpected_data.geographic_unit_fips.tolist()
     assert len(unexpected_data) == 1
-    assert len(unexpected_data[unexpected_data["predictive"]]) == 1
+    assert len(unexpected_data[unexpected_data["unit_category"] == "unexpected"]) == 1
 
     assert len(reporting_units) == 20 - 1
     assert va_governor_county_data.loc[0].geographic_unit_fips not in reporting_units.geographic_unit_fips.tolist()
@@ -348,5 +350,5 @@ def test_turnout_factor_as_non_predictive(va_governor_county_data):
     under = combined_data_handler.data[combined_data_handler.data.turnout_factor < turnout_factor_lower].shape[0]
     assert unexpected_data.shape[0] == over + under
     assert (
-        len(unexpected_data[~unexpected_data["predictive"]]) == (over + under) - 1
+        len(unexpected_data[unexpected_data["unit_category"] == "non-modeled"]) == (over + under) - 1
     )  # data contains one predictive unit

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -318,7 +318,7 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
 
     assert va_governor_county_data.loc[0].geographic_unit_fips in unexpected_data.geographic_unit_fips.tolist()
     assert len(unexpected_data) == 1
-    assert len(unexpected_data[unexpected_data["unit_category"] == "unexpected"]) == 1
+    assert len(unexpected_data[unexpected_data["unit_category"] == "non-modeled"]) == 1
 
     assert len(reporting_units) == 20 - 1
     assert va_governor_county_data.loc[0].geographic_unit_fips not in reporting_units.geographic_unit_fips.tolist()
@@ -349,6 +349,4 @@ def test_turnout_factor_as_non_predictive(va_governor_county_data):
     over = combined_data_handler.data[combined_data_handler.data.turnout_factor >= turnout_factor_upper].shape[0]
     under = combined_data_handler.data[combined_data_handler.data.turnout_factor < turnout_factor_lower].shape[0]
     assert unexpected_data.shape[0] == over + under
-    assert (
-        len(unexpected_data[unexpected_data["unit_category"] == "non-modeled"]) == (over + under) - 1
-    )  # data contains one predictive unit
+    assert len(unexpected_data[unexpected_data["unit_category"] == "non-modeled"]) == over + under

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -176,7 +176,7 @@ def test_get_reporting_data(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.5
     turnout_factor_upper = 1.5
-    observed_data = combined_data_handler.get_reporting_units(100, turnout_factor_lower, turnout_factor_upper)
+    (observed_data, _, _) = combined_data_handler.get_units(100, turnout_factor_lower, turnout_factor_upper, [])
     assert observed_data.shape[0] == 20
     assert observed_data.reporting.iloc[0] == 1
     assert observed_data.reporting.sum() == 20
@@ -208,7 +208,7 @@ def test_get_reporting_data_dropping_with_turnout_factor(va_governor_county_data
         & (combined_data_handler.data.turnout_factor < turnout_factor_lower)
     ].shape[0]
 
-    observed_data = combined_data_handler.get_reporting_units(100, turnout_factor_lower, turnout_factor_upper)
+    (observed_data, _, _) = combined_data_handler.get_units(100, turnout_factor_lower, turnout_factor_upper, [])
 
     # 20 units should be reporting,
     # but the additional ones are dropped to unexpected because they are above/below threshold
@@ -242,8 +242,8 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
     turnout_factor_lower = 0  # set to extreme values so as not to add any more "unexpected"
     turnout_factor_upper = 100
     # TODO: assertions on non_predictive_data
-    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
-        100, ["county_fips", "district"], turnout_factor_lower, turnout_factor_upper
+    (_, _, unexpected_data) = combined_data_handler.get_units(
+        100, turnout_factor_lower, turnout_factor_upper, ["county_fips", "district"]
     )
     assert unexpected_data.shape[0] == unexpected_units
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0
@@ -280,8 +280,8 @@ def test_get_unexpected_units_county(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.5
     turnout_factor_upper = 1.5
-    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
-        100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
+    (_, _, unexpected_data) = combined_data_handler.get_units(
+        100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
     # TODO: assertions on non_predictive_data
     assert unexpected_data.shape[0] == reporting_unexpected_units + 1
@@ -308,18 +308,18 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.5
     turnout_factor_upper = 1.5
-    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
-        100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
+
+    (reporting_units, nonreporting_units, unexpected_data) = combined_data_handler.get_units(
+        100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
+
     # TODO: assertions on non_predictive_data
     assert va_governor_county_data.loc[0].geographic_unit_fips in unexpected_data.geographic_unit_fips.tolist()
     assert len(unexpected_data) == 1
 
-    reporting_units = combined_data_handler.get_reporting_units(100, turnout_factor_lower, turnout_factor_upper)
     assert len(reporting_units) == 20 - 1
     assert va_governor_county_data.loc[0].geographic_unit_fips not in reporting_units.geographic_unit_fips.tolist()
 
-    nonreporting_units = combined_data_handler.get_nonreporting_units(100, turnout_factor_lower, turnout_factor_upper)
     assert va_governor_county_data.loc[0].geographic_unit_fips not in nonreporting_units.geographic_unit_fips.tolist()
 
 
@@ -340,9 +340,11 @@ def test_turnout_factor_as_non_predictive(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.95
     turnout_factor_upper = 1.2
-    (_, non_predictive_data) = combined_data_handler.get_unexpected_units(
-        100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
+    (_, _, non_predictive_data) = combined_data_handler.get_units(
+        100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
     over = combined_data_handler.data[combined_data_handler.data.turnout_factor >= turnout_factor_upper].shape[0]
     under = combined_data_handler.data[combined_data_handler.data.turnout_factor < turnout_factor_lower].shape[0]
     non_predictive_data.shape[0] == over + under
+
+    # TODO: assertion here

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -241,7 +241,8 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
     combined_data_handler = CombinedDataHandler(va_assembly_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0  # set to extreme values so as not to add any more "unexpected"
     turnout_factor_upper = 100
-    unexpected_data = combined_data_handler.get_unexpected_units(
+    # TODO: assertions on non_predictive_data
+    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
         100, ["county_fips", "district"], turnout_factor_lower, turnout_factor_upper
     )
     assert unexpected_data.shape[0] == unexpected_units
@@ -279,9 +280,10 @@ def test_get_unexpected_units_county(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.5
     turnout_factor_upper = 1.5
-    unexpected_data = combined_data_handler.get_unexpected_units(
+    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
         100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
     )
+    # TODO: assertions on non_predictive_data
     assert unexpected_data.shape[0] == reporting_unexpected_units + 1
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0
     assert unexpected_data["county_fips"].map(lambda x: len(x) == 6).all()
@@ -306,9 +308,10 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.5
     turnout_factor_upper = 1.5
-    unexpected_data = combined_data_handler.get_unexpected_units(
+    (unexpected_data, non_predictive_data) = combined_data_handler.get_unexpected_units(
         100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
     )
+    # TODO: assertions on non_predictive_data
     assert va_governor_county_data.loc[0].geographic_unit_fips in unexpected_data.geographic_unit_fips.tolist()
     assert len(unexpected_data) == 1
 
@@ -320,7 +323,7 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
     assert va_governor_county_data.loc[0].geographic_unit_fips not in nonreporting_units.geographic_unit_fips.tolist()
 
 
-def test_turnout_factor_as_unexpected(va_governor_county_data):
+def test_turnout_factor_as_non_predictive(va_governor_county_data):
     election_id = "2017-11-07_VA_G"
     office = "G"
     geographic_unit_type = "county"
@@ -337,9 +340,9 @@ def test_turnout_factor_as_unexpected(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.95
     turnout_factor_upper = 1.2
-    unexpected_data = combined_data_handler.get_unexpected_units(
+    (_, non_predictive_data) = combined_data_handler.get_unexpected_units(
         100, ["county_fips"], turnout_factor_lower, turnout_factor_upper
     )
     over = combined_data_handler.data[combined_data_handler.data.turnout_factor >= turnout_factor_upper].shape[0]
     under = combined_data_handler.data[combined_data_handler.data.turnout_factor < turnout_factor_lower].shape[0]
-    unexpected_data.shape[0] == over + under
+    non_predictive_data.shape[0] == over + under

--- a/tests/handlers/test_combined_data.py
+++ b/tests/handlers/test_combined_data.py
@@ -241,15 +241,16 @@ def test_get_unexpected_units_county_district(va_assembly_county_data):
     combined_data_handler = CombinedDataHandler(va_assembly_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0  # set to extreme values so as not to add any more "unexpected"
     turnout_factor_upper = 100
-    # TODO: assertions on non_predictive_data
     (_, _, unexpected_data) = combined_data_handler.get_units(
         100, turnout_factor_lower, turnout_factor_upper, ["county_fips", "district"]
     )
+
     assert unexpected_data.shape[0] == unexpected_units
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0
     assert unexpected_data["county_fips"].map(lambda x: len(x) == 6).all()
     assert unexpected_data[unexpected_data.district == ""].shape[0] == 0
     assert unexpected_data["district"].map(lambda x: len(x) < 6).all()
+    assert len(unexpected_data[unexpected_data["predictive"]]) == unexpected_units
 
 
 def test_get_unexpected_units_county(va_governor_county_data):
@@ -283,12 +284,12 @@ def test_get_unexpected_units_county(va_governor_county_data):
     (_, _, unexpected_data) = combined_data_handler.get_units(
         100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
-    # TODO: assertions on non_predictive_data
     assert unexpected_data.shape[0] == reporting_unexpected_units + 1
     assert unexpected_data[unexpected_data.county_fips == ""].shape[0] == 0
     assert unexpected_data["county_fips"].map(lambda x: len(x) == 6).all()
     # test that nonreporting unexpected unit is captured here
     assert unexpected_data[unexpected_data.percent_expected_vote == 50].shape[0] == 1
+    assert len(unexpected_data[unexpected_data["predictive"]]) == reporting_unexpected_units + 1
 
 
 def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
@@ -313,9 +314,9 @@ def test_zero_baseline_turnout_as_unexpected(va_governor_county_data):
         100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
 
-    # TODO: assertions on non_predictive_data
     assert va_governor_county_data.loc[0].geographic_unit_fips in unexpected_data.geographic_unit_fips.tolist()
     assert len(unexpected_data) == 1
+    assert len(unexpected_data[unexpected_data["predictive"]]) == 1
 
     assert len(reporting_units) == 20 - 1
     assert va_governor_county_data.loc[0].geographic_unit_fips not in reporting_units.geographic_unit_fips.tolist()
@@ -340,11 +341,12 @@ def test_turnout_factor_as_non_predictive(va_governor_county_data):
     combined_data_handler = CombinedDataHandler(va_governor_county_data, current_data, estimands, geographic_unit_type)
     turnout_factor_lower = 0.95
     turnout_factor_upper = 1.2
-    (_, _, non_predictive_data) = combined_data_handler.get_units(
+    (_, _, unexpected_data) = combined_data_handler.get_units(
         100, turnout_factor_lower, turnout_factor_upper, ["county_fips"]
     )
     over = combined_data_handler.data[combined_data_handler.data.turnout_factor >= turnout_factor_upper].shape[0]
     under = combined_data_handler.data[combined_data_handler.data.turnout_factor < turnout_factor_lower].shape[0]
-    non_predictive_data.shape[0] == over + under
-
-    # TODO: assertion here
+    assert unexpected_data.shape[0] == over + under
+    assert (
+        len(unexpected_data[~unexpected_data["predictive"]]) == (over + under) - 1
+    )  # data contains one predictive unit

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -87,8 +87,17 @@ def test_column_names():
             "d": [1, 2, 3, 4, 5, 3, 1, 5],
             "fe_a": ["a", "a", "b", "c", "a", "a", "b", "d"],
             "fe_b": ["1", "x", "7", "y", "1", "z", "z", "w"],
-            "reporting": [True, True, True, True, False, False, False, False],
-            "expected": [True, True, True, True, False, False, False, False],
+            "reporting": [1, 1, 1, 1, 0, 0, 0, 0],
+            "unit_category": [
+                "reporting",
+                "reporting",
+                "reporting",
+                "reporting",
+                "non-reporting",
+                "non-reporting",
+                "non-reporting",
+                "non-reporting",
+            ],
         }
     )
     df_new = featurizer.prepare_data(df, center_features=False, scale_features=False, add_intercept=True)
@@ -158,8 +167,17 @@ def test_generating_heldout_set():
             "d": [1, 2, 3, 4, 5, 3, 1, 5],
             "fe_a": ["a", "a", "b", "c", "a", "a", "b", "d"],
             "fe_b": ["1", "x", "7", "y", "1", "z", "z", "w"],
-            "reporting": [True, True, True, True, False, False, False, False],
-            "expected": [True, True, True, True, False, False, False, False],
+            "reporting": [1, 1, 1, 1, 0, 0, 0, 0],
+            "unit_category": [
+                "reporting",
+                "reporting",
+                "reporting",
+                "reporting",
+                "non-reporting",
+                "non-reporting",
+                "non-reporting",
+                "non-reporting",
+            ],
         }
     )
 

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -88,16 +88,7 @@ def test_column_names():
             "fe_a": ["a", "a", "b", "c", "a", "a", "b", "d"],
             "fe_b": ["1", "x", "7", "y", "1", "z", "z", "w"],
             "reporting": [1, 1, 1, 1, 0, 0, 0, 0],
-            "unit_category": [
-                "reporting",
-                "reporting",
-                "reporting",
-                "reporting",
-                "non-reporting",
-                "non-reporting",
-                "non-reporting",
-                "non-reporting",
-            ],
+            "unit_category": ["expected"] * 8,
         }
     )
     df_new = featurizer.prepare_data(df, center_features=False, scale_features=False, add_intercept=True)
@@ -168,16 +159,7 @@ def test_generating_heldout_set():
             "fe_a": ["a", "a", "b", "c", "a", "a", "b", "d"],
             "fe_b": ["1", "x", "7", "y", "1", "z", "z", "w"],
             "reporting": [1, 1, 1, 1, 0, 0, 0, 0],
-            "unit_category": [
-                "reporting",
-                "reporting",
-                "reporting",
-                "reporting",
-                "non-reporting",
-                "non-reporting",
-                "non-reporting",
-                "non-reporting",
-            ],
+            "unit_category": ["expected"] * 8,
         }
     )
 

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -347,8 +347,7 @@ def test_generate_fixed_effects(va_governor_county_data):
         handle_unreporting="drop",
     )
 
-    reporting_data = combined_data_handler.get_reporting_units(99, 0.5, 1.5)
-    nonreporting_data = combined_data_handler.get_nonreporting_units(99, 0.5, 1.5)
+    (reporting_data, nonreporting_data, _) = combined_data_handler.get_units(99, 0.5, 1.5, [])
 
     featurizer = Featurizer([], {"county_classification": "all"})
 
@@ -382,8 +381,7 @@ def test_generate_fixed_effects(va_governor_county_data):
 
     featurizer = Featurizer([], {"county_classification": ["all"], "county_fips": ["all"]})
 
-    reporting_data = combined_data_handler.get_reporting_units(99, 0.5, 1.5)
-    nonreporting_data = combined_data_handler.get_nonreporting_units(99, 0.5, 1.5)
+    (reporting_data, nonreporting_data, _) = combined_data_handler.get_units(99, 0.5, 1.5, [])
 
     n_train = reporting_data.shape[0]
     all_units = pd.concat([reporting_data, nonreporting_data], axis=0)
@@ -438,8 +436,7 @@ def test_generate_fixed_effects_not_all_reporting(va_governor_county_data):
         handle_unreporting="drop",
     )
 
-    reporting_data = combined_data_handler.get_reporting_units(99, 0.5, 1.5)
-    nonreporting_data = combined_data_handler.get_nonreporting_units(99, 0.5, 1.5)
+    (reporting_data, nonreporting_data, _) = combined_data_handler.get_units(99, 0.5, 1.5, [])
 
     featurizer = Featurizer([], {"county_fips": ["all"]})
     n_train = reporting_data.shape[0]
@@ -504,8 +501,7 @@ def test_generate_fixed_effects_mixed_reporting(va_governor_precinct_data):
         handle_unreporting="drop",
     )
 
-    reporting_data = combined_data_handler.get_reporting_units(99, 0.5, 1.5)
-    nonreporting_data = combined_data_handler.get_nonreporting_units(99, 0.5, 1.5)
+    (reporting_data, nonreporting_data, _) = combined_data_handler.get_units(99, 0.5, 1.5, [])
 
     featurizer = Featurizer([], ["county_fips"])
 

--- a/tests/handlers/test_model_results.py
+++ b/tests/handlers/test_model_results.py
@@ -11,7 +11,7 @@ reporting = pd.DataFrame(
         "results_e1": [1000, 2000],
         "results_e2": [400, 1200],
         "reporting": [1, 1],
-        "unit_category": ["reporting", "reporting"],
+        "unit_category": ["expected", "expected"],
     }
 )
 nonreporting = pd.DataFrame(
@@ -20,7 +20,7 @@ nonreporting = pd.DataFrame(
         "postal_code": ["AB"],
         "district": ["8"],
         "reporting": [0],
-        "unit_category": ["non-reporting"],
+        "unit_category": ["expected"],
     }
 )
 notexpected = pd.DataFrame(

--- a/tests/handlers/test_model_results.py
+++ b/tests/handlers/test_model_results.py
@@ -11,9 +11,18 @@ reporting = pd.DataFrame(
         "results_e1": [1000, 2000],
         "results_e2": [400, 1200],
         "reporting": [1, 1],
+        "unit_category": ["reporting", "reporting"],
     }
 )
-nonreporting = pd.DataFrame({"geographic_unit_fips": ["c"], "postal_code": ["AB"], "district": ["8"], "reporting": [0]})
+nonreporting = pd.DataFrame(
+    {
+        "geographic_unit_fips": ["c"],
+        "postal_code": ["AB"],
+        "district": ["8"],
+        "reporting": [0],
+        "unit_category": ["non-reporting"],
+    }
+)
 notexpected = pd.DataFrame(
     {
         "geographic_unit_fips": ["d"],
@@ -22,6 +31,7 @@ notexpected = pd.DataFrame(
         "results_e1": [0],
         "results_e2": [0],
         "reporting": [0],
+        "unit_category": ["unexpected"],
     }
 )
 predictions_e1 = [1200]

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -73,11 +73,12 @@ def test_estimate_model_error(bootstrap_election_model, rng):
 
 def test_get_strata(bootstrap_election_model):
     reporting_units = pd.DataFrame(
-        [["a", True, True], ["b", True, True], ["c", True, True]],
-        columns=["county_classification", "reporting", "expected"],
+        [["a", 1, "reporting"], ["b", 1, "reporting"], ["c", 1, "reporting"]],
+        columns=["county_classification", "reporting", "unit_category"],
     )
     nonreporting_units = pd.DataFrame(
-        [["c", False, True], ["d", False, True]], columns=["county_classification", "reporting", "expected"]
+        [["c", 0, "non-reporting"], ["d", 0, "non-reporting"]],
+        columns=["county_classification", "reporting", "unit_category"],
     )
     x_train_strata, x_test_strata = bootstrap_election_model._get_strata(reporting_units, nonreporting_units)
 

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -73,11 +73,11 @@ def test_estimate_model_error(bootstrap_election_model, rng):
 
 def test_get_strata(bootstrap_election_model):
     reporting_units = pd.DataFrame(
-        [["a", 1, "reporting"], ["b", 1, "reporting"], ["c", 1, "reporting"]],
+        [["a", 1, "expected"], ["b", 1, "expected"], ["c", 1, "expected"]],
         columns=["county_classification", "reporting", "unit_category"],
     )
     nonreporting_units = pd.DataFrame(
-        [["c", 0, "non-reporting"], ["d", 0, "non-reporting"]],
+        [["c", 0, "expected"], ["d", 0, "expected"]],
         columns=["county_classification", "reporting", "unit_category"],
     )
     x_train_strata, x_test_strata = bootstrap_election_model._get_strata(reporting_units, nonreporting_units)

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -492,21 +492,11 @@ def test_compute_bootstrap_errors(bootstrap_election_model, va_governor_county_d
 
     turnout_factor_lower = 0.5
     turnout_factor_upper = 2.0
-    reporting_units = combined_data_handler.get_reporting_units(
+    (reporting_units, nonreporting_units, unexpected_units) = combined_data_handler.get_units(
         percent_reporting_threshold,
         turnout_factor_lower=turnout_factor_lower,
         turnout_factor_upper=turnout_factor_upper,
-    )
-    nonreporting_units = combined_data_handler.get_nonreporting_units(
-        percent_reporting_threshold,
-        turnout_factor_lower=turnout_factor_lower,
-        turnout_factor_upper=turnout_factor_upper,
-    )
-    unexpected_units = combined_data_handler.get_unexpected_units(
-        percent_reporting_threshold,
-        ["postal_code"],
-        turnout_factor_lower=turnout_factor_lower,
-        turnout_factor_upper=turnout_factor_upper,
+        aggregates=["postal_code"],
     )
 
     assert not bootstrap_election_model.ran_bootstrap
@@ -545,18 +535,11 @@ def test_get_unit_predictions(bootstrap_election_model, va_governor_county_data)
 
     turnout_factor_lower = 0.5
     turnout_factor_upper = 2.0
-    reporting_units = combined_data_handler.get_reporting_units(
+    (reporting_units, nonreporting_units, unexpected_units) = combined_data_handler.get_units(
         percent_reporting_threshold,
         turnout_factor_lower=turnout_factor_lower,
         turnout_factor_upper=turnout_factor_upper,
-    )
-    nonreporting_units = combined_data_handler.get_nonreporting_units(
-        percent_reporting_threshold,
-        turnout_factor_lower=turnout_factor_lower,
-        turnout_factor_upper=turnout_factor_upper,
-    )
-    unexpected_units = combined_data_handler.get_unexpected_units(
-        percent_reporting_threshold, ["postal_code"], turnout_factor_lower, turnout_factor_upper
+        aggregates=["postal_code"],
     )
 
     bootstrap_election_model.B = 10
@@ -1316,13 +1299,8 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
         preprocessed_data_handler.data, current_data, estimands, geographic_unit_type
     )
 
-    reporting_units = combined_data_handler.get_reporting_units(percent_reporting_threshold, 0.5, 1.5)
-    nonreporting_units = combined_data_handler.get_nonreporting_units(percent_reporting_threshold, 0.5, 1.5)
-    unexpected_units = combined_data_handler.get_unexpected_units(
-        percent_reporting_threshold,
-        aggregates=["postal_code", "district"],
-        turnout_factor_lower=0.5,
-        turnout_factor_upper=1.5,
+    (reporting_units, nonreporting_units, unexpected_units) = combined_data_handler.get_units(
+        percent_reporting_threshold, 0.5, 1.5, ["postal_code", "district"]
     )
 
     bootstrap_election_model.B = 300

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -474,10 +474,10 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
         "geographic_unit_fips",
         "pred_turnout",
         "reporting",
+        "unit_category",
         "lower_0.9_turnout",
         "upper_0.9_turnout",
         "results_turnout",
-        "unit_category",
     ]
 
     assert result["state_data"]["postal_code"][0] == "VA"
@@ -648,10 +648,10 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         "geographic_unit_fips",
         "pred_turnout",
         "reporting",
+        "unit_category",
         "lower_0.9_turnout",
         "upper_0.9_turnout",
         "results_turnout",
-        "unit_category",
     ]
     assert result["state_data"]["postal_code"][0] == "VA"
     assert result["state_data"]["pred_turnout"][0] == 2587563.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -459,7 +459,7 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
     )
 
     assert result["state_data"].shape == (1, 6)
-    assert result["unit_data"].shape == (133, 7)
+    assert result["unit_data"].shape == (133, 8)
 
     assert list(result["state_data"].columns.values) == [
         "postal_code",
@@ -477,6 +477,7 @@ def test_get_estimates_fully_reporting(model_client, va_governor_county_data, va
         "lower_0.9_turnout",
         "upper_0.9_turnout",
         "results_turnout",
+        "unit_category",
     ]
 
     assert result["state_data"]["postal_code"][0] == "VA"
@@ -632,7 +633,7 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         save_output=[],
     )
     assert result["state_data"].shape == (1, 6)
-    assert result["unit_data"].shape == (133, 7)
+    assert result["unit_data"].shape == (133, 8)
 
     assert list(result["state_data"].columns.values) == [
         "postal_code",
@@ -650,6 +651,7 @@ def test_get_estimates_some_reporting(model_client, va_governor_county_data, va_
         "lower_0.9_turnout",
         "upper_0.9_turnout",
         "results_turnout",
+        "unit_category",
     ]
     assert result["state_data"]["postal_code"][0] == "VA"
     assert result["state_data"]["pred_turnout"][0] == 2587563.0


### PR DESCRIPTION
## Description

Hi!  The changes in this PR:

* refactor the way we determine reporting units, non-reporting units, and unexpected units so that `_get_unexpected_units()` is only called once rather than three times (which was once per each of reporting, non-reporting, and unexpected);
* introduce the `predictive` indicator in the dataframe of unexpected units, where `True` means the unit is genuinely unexpected but predictive, and `False` means otherwise (currently above/below the turnout factor thresholds);
* log a dictionary of non-predictive units that looks like `{postal_code : [list of geographic_unit_fips]}`;
* provide unit tests for these

🎉 

## Jira Ticket

[ELEX-3394] although this only resolves the "Thoughts" section of the ticket 😄  (Hence "Part 1")

## Test Steps

`tox` or here's a CLI command that returns one non-predictive unit:

```
elexmodel 2022-11-08_USA_G --estimands=margin --features=baseline_normalized_margin --office_id=G_county --geographic_unit_type=county --pi_method bootstrap --national_summary --save_output results
```

[ELEX-3394]: https://arcpublishing.atlassian.net/browse/ELEX-3394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ