### PR TITLE
Elex 3393 override model racecall

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Parameters for the CLI tool:
 | aggregates           | list    | list of geographies for which to calculate predictions beyond the original `postal_code`, `county_fips`, `district`, `county_classification` |
 | pi_method            | string  | method for constructing prediction intervals (`nonparametric` or `gaussian`) |
 | model_parameters     | dict    | dictionary of model specific parameters e.g. `--model_parameters='{"robust":True}'` |
-| called_contests      | dict    | a dictionary of called contests. specific to Bootstrap model for now. e.g. `--called_contests='{"VA": -1}'` |
+| lhs_called_contests  | list    | a list of states called for lhs party (ie. ones where prediction > 0) |
+| rhs_called_contests  | list    | a list of states called for rhs party (ie. ones where prediction < 0) |
+| stop_model_call      | list    | a list of states for which we should override the model call |
 | save_output          | list    | `results`, `data`, `config` |
 | unexpected_units     | int     | number of unexpected units to simulate; only used for testing and does not work with historical run |
 | national_summary     | flag    | When not running a historical election, specify this flag to output national summary (aggregate model) estimates. |

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -53,9 +53,19 @@ class PythonLiteralOption(click.Option):
     help="A dictionary of model parameters",
 )
 @click.option(
-    "--lhs_called_contests", "lhs_called_contests", help="contests called for the lhs party (ie. the party for which margin predictions > 0 are winners)", default=None, multiple=True)
+    "--lhs_called_contests",
+    "lhs_called_contests",
+    help="contests called for the lhs party (ie. the party for which margin predictions > 0 are winners)",
+    default=None,
+    multiple=True,
+)
 @click.option(
-    "--rhs_called_contests", "rhs_called_contests", help="contests called for the rhs party (ie. the party for which margin predictions < 0 are winners)", default=None, multiple=True)
+    "--rhs_called_contests",
+    "rhs_called_contests",
+    help="contests called for the rhs party (ie. the party for which margin predictions < 0 are winners)",
+    default=None,
+    multiple=True,
+)
 @click.option(
     "--stop_model_call",
     "stop_model_call",

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -56,7 +56,11 @@ class PythonLiteralOption(click.Option):
     "--called_contests", "called_contests", default="{}", cls=PythonLiteralOption, help="A dictionary with race calls"
 )
 @click.option(
-    "--allow_model_call", "allow_model_call", default="{}", cls=PythonLiteralOption, help="A dictionary to allow model race calls"
+    "--allow_model_call",
+    "allow_model_call",
+    default="{}",
+    cls=PythonLiteralOption,
+    help="A dictionary to allow model race calls",
 )
 @click.option(
     "--percent_reporting",

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -56,6 +56,9 @@ class PythonLiteralOption(click.Option):
     "--called_contests", "called_contests", default="{}", cls=PythonLiteralOption, help="A dictionary with race calls"
 )
 @click.option(
+    "--allow_model_call", "allow_model_call", default="{}", cls=PythonLiteralOption, help="A dictionary to allow model race calls"
+)
+@click.option(
     "--percent_reporting",
     "percent_reporting",
     default=100,

--- a/src/elexmodel/cli.py
+++ b/src/elexmodel/cli.py
@@ -53,14 +53,15 @@ class PythonLiteralOption(click.Option):
     help="A dictionary of model parameters",
 )
 @click.option(
-    "--called_contests", "called_contests", default="{}", cls=PythonLiteralOption, help="A dictionary with race calls"
-)
+    "--lhs_called_contests", "lhs_called_contests", help="contests called for the lhs party (ie. the party for which margin predictions > 0 are winners)", default=None, multiple=True)
 @click.option(
-    "--allow_model_call",
-    "allow_model_call",
-    default="{}",
-    cls=PythonLiteralOption,
-    help="A dictionary to allow model race calls",
+    "--rhs_called_contests", "rhs_called_contests", help="contests called for the rhs party (ie. the party for which margin predictions < 0 are winners)", default=None, multiple=True)
+@click.option(
+    "--stop_model_call",
+    "stop_model_call",
+    default=None,
+    multiple=True,
+    help="contests for which we don't allow model calls",
 )
 @click.option(
     "--percent_reporting",

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -398,7 +398,7 @@ class ModelClient:
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
                         called_contests=called_contests,
-                        allow_model_call=allow_model_call
+                        allow_model_call=allow_model_call,
                     )
                     if isinstance(self.model, ConformalElectionModel):
                         self.all_conformalization_data_agg_dict[alpha][

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -219,6 +219,7 @@ class ModelClient:
         fixed_effects = kwargs.get("fixed_effects", {})
         pi_method = kwargs.get("pi_method", "nonparametric")
         called_contests = kwargs.get("called_contests", None)
+        allow_model_call = kwargs.get("allow_model_call", None)
         save_output = kwargs.get("save_output", ["results"])
         self.save_results = "results" in save_output
         save_data = "data" in save_output
@@ -394,6 +395,7 @@ class ModelClient:
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
                         called_contests=called_contests,
+                        allow_model_call=allow_model_call
                     )
                     if isinstance(self.model, ConformalElectionModel):
                         self.all_conformalization_data_agg_dict[alpha][

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -387,7 +387,7 @@ class ModelClient:
                     aggregate_list,
                     estimand,
                     lhs_called_contests=lhs_called_contests,
-                    rhs_called_contests=rhs_called_contests
+                    rhs_called_contests=rhs_called_contests,
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:

--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -218,8 +218,9 @@ class ModelClient:
         aggregates = kwargs.get("aggregates", DEFAULT_AGGREGATES[office])
         fixed_effects = kwargs.get("fixed_effects", {})
         pi_method = kwargs.get("pi_method", "nonparametric")
-        called_contests = kwargs.get("called_contests", None)
-        allow_model_call = kwargs.get("allow_model_call", None)
+        lhs_called_contests = kwargs.get("lhs_called_contests", [])
+        rhs_called_contests = kwargs.get("rhs_called_contests", [])
+        stop_model_call = kwargs.get("stop_model_call", [])
         save_output = kwargs.get("save_output", ["results"])
         self.save_results = "results" in save_output
         save_data = "data" in save_output
@@ -385,7 +386,8 @@ class ModelClient:
                     self.results_handler.unexpected_units,
                     aggregate_list,
                     estimand,
-                    called_contests=called_contests,
+                    lhs_called_contests=lhs_called_contests,
+                    rhs_called_contests=rhs_called_contests
                 )
                 alpha_to_agg_prediction_intervals = {}
                 for alpha in prediction_intervals:
@@ -397,8 +399,9 @@ class ModelClient:
                         alpha,
                         alpha_to_unit_prediction_intervals[alpha],
                         estimand,
-                        called_contests=called_contests,
-                        allow_model_call=allow_model_call,
+                        lhs_called_contests=lhs_called_contests,
+                        rhs_called_contests=rhs_called_contests,
+                        stop_model_call=stop_model_call,
                     )
                     if isinstance(self.model, ConformalElectionModel):
                         self.all_conformalization_data_agg_dict[alpha][

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1134,14 +1134,12 @@ class BootstrapElectionModel(BaseElectionModel):
             aggregate_temp_column_name = "-".join(aggregate)
             all_units[aggregate_temp_column_name] = all_units[aggregate].agg("_".join, axis=1)
             dummies = pd.get_dummies(all_units[aggregate_temp_column_name])
-            aggregate_indicator = dummies.values
-            contests = dummies.columns
         else:
             # since aggregate is of length zero we can grab the first element
             dummies = pd.get_dummies(all_units[aggregate[0]])
-            aggregate_indicator = dummies.values
-            contests = dummies.columns
             aggregate_temp_column_name = aggregate
+        aggregate_indicator = dummies.values
+        contests = dummies.columns
 
         # the unit level predictions that come in through reporting_units and nonreporting_units
         # are unnormalized. Since we want the normalized margin for the aggregate predictions
@@ -1281,13 +1279,12 @@ class BootstrapElectionModel(BaseElectionModel):
             aggregate_temp_column_name = "-".join(aggregate)
             all_units[aggregate_temp_column_name] = all_units[aggregate].agg("_".join, axis=1)
             dummies = pd.get_dummies(all_units[aggregate_temp_column_name])
-            aggregate_indicator = dummies.values
-            contests = dummies.columns
         else:
             # since aggregate is of length one, we can grab the first element
             dummies = pd.get_dummies(all_units[aggregate[0]])
-            aggregate_indicator = dummies.values
-            contests = dummies.columns
+        
+        aggregate_indicator = dummies.values
+        contests = dummies.columns
         aggregate_indicator_expected = aggregate_indicator[: (n_train + n_test)]
 
         # first compute turnout and unnormalized margin for unexpected units.

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1282,7 +1282,7 @@ class BootstrapElectionModel(BaseElectionModel):
         else:
             # since aggregate is of length one, we can grab the first element
             dummies = pd.get_dummies(all_units[aggregate[0]])
-        
+
         aggregate_indicator = dummies.values
         contests = dummies.columns
         aggregate_indicator_expected = aggregate_indicator[: (n_train + n_test)]

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1362,14 +1362,20 @@ class BootstrapElectionModel(BaseElectionModel):
                     # if we don't allow the model call, then force the lower interval to be below zero and the upper interval to be above zero
                     if interval_lower_i > 0:
                         # if interval_lower_i > 0 then our model thinks the race is called for the LHS party. 
-                        error_diff[i, error_diff[i] < 0] = (
+                        # error_diff > 0 means that the lower bound is smaller than the prediction, so for those we set error_diff to be the gap between
+                        # the prediction and the imposed lower bound. This forces the difference between error_diff and the prediction to be exactly the imposed
+                        # lower bound
+                        error_diff[i, error_diff[i] > 0] = (
                             aggregate_perc_margin_total[i] - self.rhs_called_threshold
                         ).flatten()
+                        # for error_B_1 and error_B_2 we can set all of them to the imposed lower bound, because we no longer care about doing inference on the interval
                         divided_error_B_1[i, :] = self.rhs_called_threshold
                         divided_error_B_2[i, :] = self.rhs_called_threshold
                     if interval_upper_i < 0:
-                        # if interval_upper_i < 0 then our model thinks the race has been called for the RHS party
-                        error_diff[i, error_diff[i] > 0] = (
+                        # if interval_upper_i < 0 then our model thinks the race has been called for the RHS party.
+                        # error_diff < 0 means that the upper bound is larger than the prediction, so for those we set error_diff to be the gap between the prediction
+                        # and the imposed upper bound. This foces
+                        error_diff[i, error_diff[i] < 0] = (
                             self.lhs_called_threshold - aggregate_perc_margin_total[i]
                         ).flatten()
                         divided_error_B_1[i, :] = self.lhs_called_threshold

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1348,20 +1348,27 @@ class BootstrapElectionModel(BaseElectionModel):
             aggregate_perc_margin_total = self.aggregate_pred_margin
 
             called_contests = self._format_called_contests_dictionary(kwargs.get("called_contests", {}), fill_value=-1)
-            allow_model_call = self._format_called_contests_dictionary(kwargs.get("allow_model_call", {}), fill_value=True)
+            allow_model_call = self._format_called_contests_dictionary(
+                kwargs.get("allow_model_call", {}), fill_value=True
+            )
 
             interval_upper, interval_lower = (
                 aggregate_perc_margin_total - np.quantile(error_diff, q=[lower_q, upper_q], axis=-1).T
             ).T
 
-            for i, ((contest, call), (__, allow_model_call_i)) in enumerate(zip(sorted(called_contests.items(), key=lambda x: x[0]), sorted(allow_model_call.items(), key=lambda x: x[0]))):
+            for i, ((contest, call), (__, allow_model_call_i)) in enumerate(
+                zip(
+                    sorted(called_contests.items(), key=lambda x: x[0]),
+                    sorted(allow_model_call.items(), key=lambda x: x[0]),
+                )
+            ):
                 interval_lower_i = interval_lower[i]
                 interval_upper_i = interval_upper[i]
-                
+
                 if not allow_model_call_i:
                     # if we don't allow the model call, then force the lower interval to be below zero and the upper interval to be above zero
                     if interval_lower_i > 0:
-                        # if interval_lower_i > 0 then our model thinks the race is called for the LHS party. 
+                        # if interval_lower_i > 0 then our model thinks the race is called for the LHS party.
                         # error_diff > 0 means that the lower bound is smaller than the prediction, so for those we set error_diff to be the gap between
                         # the prediction and the imposed lower bound. This forces the difference between error_diff and the prediction to be exactly the imposed
                         # lower bound
@@ -1409,7 +1416,6 @@ class BootstrapElectionModel(BaseElectionModel):
                         ).flatten()
                     divided_error_B_1[i, :] = self.rhs_called_threshold
                     divided_error_B_2[i, :] = self.rhs_called_threshold
-
 
             self.divided_error_B_1 = divided_error_B_1
             self.divided_error_B_2 = divided_error_B_2

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1101,8 +1101,12 @@ class BootstrapElectionModel(BaseElectionModel):
         This functions applies race calls to the point prediction
         """
         to_call_mod = to_call.copy()
-        to_call_mod[np.isclose(called_contests, 1)] = np.maximum(self.lhs_called_threshold, to_call[np.isclose(called_contests, 1)])
-        to_call_mod[np.isclose(called_contests, 0)] = np.minimum(self.rhs_called_threshold, to_call[np.isclose(called_contests, 0)])
+        to_call_mod[np.isclose(called_contests, 1)] = np.maximum(
+            self.lhs_called_threshold, to_call[np.isclose(called_contests, 1)]
+        )
+        to_call_mod[np.isclose(called_contests, 0)] = np.minimum(
+            self.rhs_called_threshold, to_call[np.isclose(called_contests, 0)]
+        )
         return to_call_mod
 
     def get_aggregate_predictions(
@@ -1183,7 +1187,7 @@ class BootstrapElectionModel(BaseElectionModel):
             lhs_called_contests = kwargs.get("lhs_called_contests", [])
             rhs_called_contests = kwargs.get("rhs_called_contests", [])
             called_contests = self._format_called_contests(lhs_called_contests, rhs_called_contests, contests, 1, 0, -1)
-            
+
             self.aggregate_pred_margin = self._adjust_called_contests(
                 raw_margin_df.pred_margin.values, called_contests
             ).reshape(-1, 1)

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1357,7 +1357,7 @@ class BootstrapElectionModel(BaseElectionModel):
             for i, ((contest, call), (__, allow_model_call_i)) in enumerate(zip(sorted(called_contests.items(), key=lambda x: x[0]), sorted(allow_model_call.items(), key=lambda x: x[0]))):
                 interval_lower_i = interval_lower[i]
                 interval_upper_i = interval_upper[i]
-
+                
                 if not allow_model_call_i:
                     # if we don't allow the model call, then force the lower interval to be below zero and the upper interval to be above zero
                     if interval_lower_i > 0:
@@ -1368,18 +1368,23 @@ class BootstrapElectionModel(BaseElectionModel):
                         error_diff[i, error_diff[i] > 0] = (
                             aggregate_perc_margin_total[i] - self.rhs_called_threshold
                         ).flatten()
-                        # for error_B_1 and error_B_2 we can set all of them to the imposed lower bound, because we no longer care about doing inference on the interval
-                        divided_error_B_1[i, :] = self.rhs_called_threshold
-                        divided_error_B_2[i, :] = self.rhs_called_threshold
+                        # we are pushing divided_error_B_2 such that divided_error_B_2 is less than zero in 10% of cases (ie. that LHS party wins some simulations)
+                        # there will be a chance that this impacts our electoral college lower bound
+                        divided_error_B_2_quantile = np.quantile(divided_error_B_2[i, :], q=0.1)
+                        if divided_error_B_2_quantile > 0:
+                            divided_error_B_2[i, :] += self.rhs_called_threshold - divided_error_B_2_quantile
                     if interval_upper_i < 0:
                         # if interval_upper_i < 0 then our model thinks the race has been called for the RHS party.
                         # error_diff < 0 means that the upper bound is larger than the prediction, so for those we set error_diff to be the gap between the prediction
-                        # and the imposed upper bound. This foces
+                        # and the imposed upper bound. This forces the difference between error_diff and the prediction to be exactly the imposed upper bound
                         error_diff[i, error_diff[i] < 0] = (
-                            self.lhs_called_threshold - aggregate_perc_margin_total[i]
+                            aggregate_perc_margin_total[i] - self.lhs_called_threshold
                         ).flatten()
-                        divided_error_B_1[i, :] = self.lhs_called_threshold
-                        divided_error_B_2[i, :] = self.lhs_called_threshold
+                        # we are pushing divided error_B_2 such that divided_error_B_2 is greater than zero in 10% of cases (ie. that LHS party wins some simulations)
+                        # there will be some chance that this impacts our electoral college prediction upper bound
+                        divided_error_B_2_quantile = np.quantile(divided_error_B_2[i, :], q=0.9)
+                        if divided_error_B_2_quantile < 0:
+                            divided_error_B_2[i, :] += self.lhs_called_threshold - divided_error_B_2_quantile
 
                 if np.isclose(call, 1):
                     if interval_lower_i < 0:

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1122,7 +1122,7 @@ class BootstrapElectionModel(BaseElectionModel):
 
         return called_contests
 
-    def _adjust_called_contests(self, to_call: np.array, called_contests: dict) -> np.array:
+    def _adjust_called_contests(self, to_call: np.array, called_contests: list) -> np.array:
         """
         This functions applies race calls to the point prediction
         """
@@ -1132,8 +1132,8 @@ class BootstrapElectionModel(BaseElectionModel):
         # array sorted by contest, where the element is the call indicator (1, 0 or -1)
         # contest_call_array = np.array([contest_tuple[1] for contest_tuple in sorted(called_contests.items())])
         to_call_mod = to_call.values.copy()
-        to_call_mod[np.isclose(called_contests, 1)] == self.lhs_called_threshold
-        to_call_mod[np.isclose(called_contests, 0)] = self.rhs_called_threshold
+        to_call_mod[np.isclose(called_contests, 1)] = np.maximum(self.lhs_called_threshold, to_call[np.isclose(called_contests, 1)])
+        to_call_mod[np.isclose(called_contests, 0)] = np.minimum(self.rhs_called_threshold, to_call[np.isclose(called_contests, 0)])
         return to_call_mod
         # return np.where(
         #     np.isclose(called_contests, -1),
@@ -1226,7 +1226,7 @@ class BootstrapElectionModel(BaseElectionModel):
             lhs_called_contests = kwargs.get("lhs_called_contests")
             rhs_called_contests = kwargs.get("rhs_called_contests")
             called_contests = self._format_called_contests(lhs_called_contests, rhs_called_contests, contests, 1, 0, -1)
-
+            
             self.aggregate_pred_margin = self._adjust_called_contests(
                 raw_margin_df.pred_margin, called_contests
             ).reshape(-1, 1)
@@ -1416,7 +1416,7 @@ class BootstrapElectionModel(BaseElectionModel):
                 interval_lower_i = interval_lower[i]
                 interval_upper_i = interval_upper[i]
 
-                if stop_model_call:
+                if stop_model_call_i:
                     # if we don't allow the model call, then force the lower interval to be below zero and the upper interval to be above zero
                     if interval_lower_i > 0:
                         # if interval_lower_i > 0 then our model thinks the race is called for the LHS party.

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1082,30 +1082,44 @@ class BootstrapElectionModel(BaseElectionModel):
 
     #     return called_contests
 
-    def _format_called_contests(self, lhs_called_contests: list, rhs_called_contests: list | None, contests: list, lhs_value: int | bool, rhs_value: int | bool | None, fill_value: int | bool) -> np.ndarray:
+    def _format_called_contests(
+        self,
+        lhs_called_contests: list,
+        rhs_called_contests: list | None,
+        contests: list,
+        lhs_value: int | bool,
+        rhs_value: int | bool | None,
+        fill_value: int | bool,
+    ) -> np.ndarray:
         """
         Create called contest numpy array
         """
         lhs_rhs_intersection = set(lhs_called_contests) & set(rhs_called_contests)
         if len(lhs_rhs_intersection) > 0:
-            raise BootstrapElectionModelException(f"You can only call a contest for one party, not for both. Currently these contests are called for both parties: {lhs_rhs_intersection}")
+            raise BootstrapElectionModelException(
+                f"You can only call a contest for one party, not for both. Currently these contests are called for both parties: {lhs_rhs_intersection}"
+            )
 
         lhs_difference_with_contests = set(lhs_called_contests) - set(contests)
         if len(lhs_difference_with_contests) > 0:
-            raise BootstrapElectionModelException(f"You can only call contests that are being run by the model. These LHS called contests do not exist: {lhs_difference_with_contests}")
+            raise BootstrapElectionModelException(
+                f"You can only call contests that are being run by the model. These LHS called contests do not exist: {lhs_difference_with_contests}"
+            )
 
         rhs_difference_with_contests = set(rhs_called_contests) - set(contests)
         if len(rhs_difference_with_contests) > 0:
-            raise BootstrapElectionModelException(f"You can only call contests that are being run by the model. These RHS called contests do not exist: {rhs_difference_with_contests}")
+            raise BootstrapElectionModelException(
+                f"You can only call contests that are being run by the model. These RHS called contests do not exist: {rhs_difference_with_contests}"
+            )
 
-        # the order in called_coteests need 
+        # the order in called_coteests need
         called_contests = np.full(len(contests), fill_value)
         for i, contest in enumerate(contests):
             if contest in lhs_called_contests:
                 called_contests[i] = lhs_value
             elif contest in rhs_called_contests:
                 called_contests[i] = rhs_value
-        
+
         return called_contests
 
     def _adjust_called_contests(self, to_call: np.array, called_contests: dict) -> np.array:
@@ -1161,11 +1175,11 @@ class BootstrapElectionModel(BaseElectionModel):
             all_units[aggregate_temp_column_name] = all_units[aggregate].agg("_".join, axis=1)
             dummies = pd.get_dummies(all_units[aggregate_temp_column_name])
             aggregate_indicator = dummies.values
-            contests = [x.split('_')[-1] for x in dummies.columns]
+            contests = [x.split("_")[-1] for x in dummies.columns]
         else:
             dummies = pd.get_dummies(all_units[aggregate])
             aggregate_indicator = dummies.values
-            contests = [x.split('_')[-1] for x in dummies.columns]
+            contests = [x.split("_")[-1] for x in dummies.columns]
             aggregate_temp_column_name = aggregate
 
         # the unit level predictions that come in through reporting_units and nonreporting_units
@@ -1307,11 +1321,11 @@ class BootstrapElectionModel(BaseElectionModel):
             all_units[aggregate_temp_column_name] = all_units[aggregate].agg("_".join, axis=1)
             dummies = pd.get_dummies(all_units[aggregate_temp_column_name])
             aggregate_indicator = dummies.values
-            contests = [x.split('_')[-1] for x in dummies.columns]
+            contests = [x.split("_")[-1] for x in dummies.columns]
         else:
             dummies = pd.get_dummies(all_units[aggregate])
             aggregate_indicator = dummies.values
-            contests = [x.split('_')[-1] for x in dummies.columns]
+            contests = [x.split("_")[-1] for x in dummies.columns]
         aggregate_indicator_expected = aggregate_indicator[: (n_train + n_test)]
 
         # first compute turnout and unnormalized margin for unexpected units.

--- a/tests/handlers/test_model_results.py
+++ b/tests/handlers/test_model_results.py
@@ -94,7 +94,7 @@ def test_model_results_handler():
     expected_cols_agg = ["pred", "lower_0.7", "lower_0.9", "upper_0.7", "upper_0.9"]
     for v in handler.estimates.values():
         for i, df in enumerate(v):
-            expected_cols = [f"{x}_e{i+1}" for x in expected_cols_agg]
+            expected_cols = [f"{x}_e{i+1}" for x in expected_cols_agg]  # noqa: E226
             assert set(expected_cols).issubset(set(df.columns))
 
     # test preparation of final results data

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -1397,4 +1397,3 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
 
     assert all(district_lower.flatten() <= district_predictions.pred_margin + TOL)
     assert all(district_predictions.pred_margin <= district_upper.flatten() + TOL)
-

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -1345,7 +1345,7 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
     )
 
     live_data_handler.shuffle()
-    current_data = live_data_handler.get_percent_fully_reported(400)
+    current_data = live_data_handler.get_percent_fully_reported(95)
 
     preprocessed_data_handler = PreprocessedDataHandler(
         election_id, office_id, geographic_unit_type, estimands, estimands_baseline, data=va_assembly_precinct_data
@@ -1397,3 +1397,4 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
 
     assert all(district_lower.flatten() <= district_predictions.pred_margin + TOL)
     assert all(district_predictions.pred_margin <= district_upper.flatten() + TOL)
+

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -1115,9 +1115,19 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     # test with allow race call being set to False
     allow_model_call = {x: False for x in range(bootstrap_election_model.n_contests)}
     called_contests = {x: -1 for x in range(bootstrap_election_model.n_contests)}
-    lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(reporting_units, nonreporting_units, unexpected_units, ["postal_code"], 0.95, None, None, called_contests=called_contests, allow_model_call=allow_model_call)
-    # note that (c) is totally reporting, so there is zero uncertainty left, so we expect that 
-    assert (lower[3] < 0) & (upper[3] > 0) # prior to this, (d) has an upper interval below zero also
+    lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code"],
+        0.95,
+        None,
+        None,
+        called_contests=called_contests,
+        allow_model_call=allow_model_call,
+    )
+    # note that (c) is totally reporting, so there is zero uncertainty left, so we expect that
+    assert (lower[3] < 0) & (upper[3] > 0)  # prior to this, (d) has an upper interval below zero also
 
     # test with more complicated aggregate
     bootstrap_election_model.n_contests = 8  # (a, c), (a, a), (b, a), (c, c), (d, c), (e, e), (e, a), (f, f)
@@ -1136,8 +1146,6 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert lower[7] == pytest.approx(upper[7])  # c-c is fully reporting
     assert lower[7] == pytest.approx(upper[7])  # f-f is fully unexpected
     assert all(lower <= upper)
-
-
 
 
 def test_get_national_summary_estimates(bootstrap_election_model, rng):
@@ -1314,6 +1322,7 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     with pytest.raises(BootstrapElectionModelException):
         nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(nat_sum_data_dict, 0, 0.95)
 
+
 # TODO: write unit test for combined aggregation (e.g. prediction, intervals, aggregate etc.)
 # also where an unexpected or non reporting unit starts ahead of an reporting unit
 def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
@@ -1388,4 +1397,3 @@ def test_total_aggregation(bootstrap_election_model, va_assembly_precinct_data):
 
     assert all(district_lower.flatten() <= district_predictions.pred_margin + TOL)
     assert all(district_predictions.pred_margin <= district_upper.flatten() + TOL)
-

--- a/tests/models/test_bootstrap_election_model.py
+++ b/tests/models/test_bootstrap_election_model.py
@@ -583,7 +583,7 @@ def test_format_called_contests(bootstrap_election_model):
     lhs = [1, 2, 3]
     rhs = [4, 5, 6]
     contests = [1, 2, 3, 4, 5, 6, 7, 8]
-    
+
     called_contests = bootstrap_election_model._format_called_contests(lhs, rhs, contests, 1, 0, -1)
     assert all(called_contests == [1, 1, 1, 0, 0, 0, -1, -1])
 
@@ -597,9 +597,9 @@ def test_format_called_contests(bootstrap_election_model):
     assert all(called_contests == [0, 0, 0, 1, 1, 1, -1, -1])
 
     # more complicated
-    lhs = ['a', 'f', 'c']
-    rhs = ['k', 'b']
-    contests = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
+    lhs = ["a", "f", "c"]
+    rhs = ["k", "b"]
+    contests = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
     called_contests = bootstrap_election_model._format_called_contests(lhs, rhs, contests, 1, 0, -1)
     assert all(called_contests == [1, 0, 1, -1, -1, 1, -1, -1, -1, -1, 0])
 
@@ -620,6 +620,7 @@ def test_format_called_contests(bootstrap_election_model):
     with pytest.raises(BootstrapElectionModelException):
         bootstrap_election_model._format_called_contests(lhs, rhs, contests, 1, 0, -1)
 
+
 def test_adjust_called_contests(bootstrap_election_model):
     called_contests = [1 + 1e-35, 1, -1 + 1e-35, -1, -1, -1, -1, -1, -1e-35, 0]
     to_call = np.asarray([0.3, -0.3, 0.2, -0.4, 0.15, -0.25, 0.86, -0.74, -0.3, 0.3])
@@ -637,6 +638,7 @@ def test_adjust_called_contests(bootstrap_election_model):
     assert (
         called[-1] == bootstrap_election_model.rhs_called_threshold
     )  # since called for RHS but positive should be repalced
+
 
 def get_data_used_for_testing_aggregate_predictions():
     reporting_units = pd.DataFrame(
@@ -764,7 +766,7 @@ def test_aggregate_predictions_with_race_call(bootstrap_election_model):
     bootstrap_election_model.weighted_z_test_pred = np.asarray([1, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
     # test with a race call
-    lhs_called_contests = ['a', 'b', 'c', 'd', 'e', 'f']
+    lhs_called_contests = ["a", "b", "c", "d", "e", "f"]
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -779,7 +781,7 @@ def test_aggregate_predictions_with_race_call(bootstrap_election_model):
     )  # since otherwise would be negative
     assert aggregate_predictions.pred_margin.iloc[1] == pytest.approx(0.9 / 2)  # should not have changed
 
-    rhs_called_contests = ['a', 'b', 'c', 'd', 'e', 'f']
+    rhs_called_contests = ["a", "b", "c", "d", "e", "f"]
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -870,7 +872,7 @@ def test_more_complicated_aggregate_predictions_with_race_call(bootstrap_electio
     ].reporting[7] == pytest.approx(0)
 
     # test with a race call
-    lhs_called_contests = ['a_a', 'a_c', 'b_a', 'c_c', 'd_c', 'e_a', 'e_e', 'f_f']
+    lhs_called_contests = ["a_a", "a_c", "b_a", "c_c", "d_c", "e_a", "e_e", "f_f"]
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -888,7 +890,7 @@ def test_more_complicated_aggregate_predictions_with_race_call(bootstrap_electio
     )  # since otherwise would be negative
     assert aggregate_predictions.pred_margin.iloc[2] == pytest.approx(0.9 / 2)  # should not have changed
 
-    rhs_called_contests = ['a_a', 'a_c', 'b_a', 'c_c', 'd_c', 'e_a', 'e_e', 'f_f']
+    rhs_called_contests = ["a_a", "a_c", "b_a", "c_c", "d_c", "e_a", "e_e", "f_f"]
     aggregate_predictions = bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -952,7 +954,9 @@ def test_get_unit_prediction_intervals(bootstrap_election_model, rng):
 def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     (reporting_units, nonreporting_units, unexpected_units) = get_data_used_for_testing_aggregate_predictions()
     reporting_units["results_normalized_margin"] = reporting_units.results_margin / reporting_units.results_weights
-    nonreporting_units["results_normalized_margin"] = nonreporting_units.results_margin / nonreporting_units.results_weights
+    nonreporting_units["results_normalized_margin"] = (
+        nonreporting_units.results_margin / nonreporting_units.results_weights
+    )
     unexpected_units["results_normalized_margin"] = unexpected_units.results_margin / unexpected_units.results_weights
 
     n = nonreporting_units.shape[0]
@@ -982,7 +986,7 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert all(lower <= upper)
 
     # test race calls
-    lhs_called_contests = ['a', 'b', 'c', 'd', 'e', 'f']
+    lhs_called_contests = ["a", "b", "c", "d", "e", "f"]
     bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -1006,7 +1010,7 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert (bootstrap_election_model.divided_error_B_1 == bootstrap_election_model.lhs_called_threshold).all()
     assert (bootstrap_election_model.divided_error_B_2 == bootstrap_election_model.lhs_called_threshold).all()
 
-    rhs_called_contests = ['a', 'b', 'c', 'd', 'e', 'f']
+    rhs_called_contests = ["a", "b", "c", "d", "e", "f"]
     bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -1031,7 +1035,7 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
     assert (bootstrap_election_model.divided_error_B_2 == bootstrap_election_model.rhs_called_threshold).all()
 
     # test with stopping all model calls
-    stop_model_call = ['a', 'b', 'c', 'd', 'e', 'f']
+    stop_model_call = ["a", "b", "c", "d", "e", "f"]
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1067,7 +1071,9 @@ def test_get_aggregate_prediction_intervals(bootstrap_election_model, rng):
 def test_get_national_summary_estimates(bootstrap_election_model, rng):
     (reporting_units, nonreporting_units, unexpected_units) = get_data_used_for_testing_aggregate_predictions()
     reporting_units["results_normalized_margin"] = reporting_units.results_margin / reporting_units.results_weights
-    nonreporting_units["results_normalized_margin"] = nonreporting_units.results_margin / nonreporting_units.results_weights
+    nonreporting_units["results_normalized_margin"] = (
+        nonreporting_units.results_margin / nonreporting_units.results_weights
+    )
     unexpected_units["results_normalized_margin"] = unexpected_units.results_margin / unexpected_units.results_weights
 
     n = nonreporting_units.shape[0]
@@ -1098,9 +1104,16 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
     assert nat_sum_estimates["margin"][0] <= nat_sum_estimates["margin"][2]
 
     # adding race call
-    lhs_called_contests = ['d', 'e', 'f']
-    stop_model_call = ['c']
-    bootstrap_election_model.get_aggregate_predictions(reporting_units, nonreporting_units, unexpected_units, ["postal_code"], "margin", lhs_called_contests=lhs_called_contests,)  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
+    lhs_called_contests = ["d", "e", "f"]
+    stop_model_call = ["c"]
+    bootstrap_election_model.get_aggregate_predictions(
+        reporting_units,
+        nonreporting_units,
+        unexpected_units,
+        ["postal_code"],
+        "margin",
+        lhs_called_contests=lhs_called_contests,
+    )  # race calling for aggregate prediction interval assumes that the point prediction has been set accordingly
     lower, upper = bootstrap_election_model.get_aggregate_prediction_intervals(
         reporting_units,
         nonreporting_units,
@@ -1110,15 +1123,17 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
         None,
         None,
         lhs_called_contests=lhs_called_contests,
-        stop_model_call=stop_model_call
+        stop_model_call=stop_model_call,
     )
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
-    assert nat_sum_estimates["margin"][0] == 4  # the 3 called ones plus the third one where we stop a call from happening
+    assert (
+        nat_sum_estimates["margin"][0] == 4
+    )  # the 3 called ones plus the third one where we stop a call from happening
     assert nat_sum_estimates["margin"][1] == 3  # the 3 called ones
     assert nat_sum_estimates["margin"][2] == 5  # all of them except the first one
 
-    rhs_called_contests = ['c', 'd', 'e', 'f']
-    lhs_called_contests = ['a']
+    rhs_called_contests = ["c", "d", "e", "f"]
+    lhs_called_contests = ["a"]
     bootstrap_election_model.get_aggregate_predictions(
         reporting_units,
         nonreporting_units,
@@ -1140,8 +1155,8 @@ def test_get_national_summary_estimates(bootstrap_election_model, rng):
         rhs_called_contests=rhs_called_contests,
     )
     nat_sum_estimates = bootstrap_election_model.get_national_summary_estimates(None, 0, 0.95)
-    assert nat_sum_estimates["margin"][0] == 1 # the first one which is called for lhs
-    assert nat_sum_estimates["margin"][1] == 1 # the first one which is called for lhs
+    assert nat_sum_estimates["margin"][0] == 1  # the first one which is called for lhs
+    assert nat_sum_estimates["margin"][1] == 1  # the first one which is called for lhs
     assert nat_sum_estimates["margin"][2] == 2  # 2nd and first
 
     # testing adding to base


### PR DESCRIPTION
## Description
This adds a feature that lets us control whether to allow for a model race call or not. If a contest is included in `stop_model_call` then then we force the prediction interval of that contest to cross zero. Correspondingly we also adjust the national summary to make sure that at least 10% of the samples from that contest cross zero also.

I also changed `called_contests` into two lists rather than one dictionary. One that specifies `lhs` calls and the other that specifies rhs calls these are `lhs_called_contests` and `rhs_called_contests` and are now just a list of called states.

## Jira Ticket
https://arcpublishing.atlassian.net/browse/ELEX-3393

## Test Steps
Running this forces the lower interval to be below zero:
```
elexmodel 2017-11-07_VA_G --estimands=margin --office_id=G --geographic_unit_type=county --pi_method bootstrap --features baseline_normalized_margin --called_contests='{"VA": -1}' --percent_reporting 95 --aggregates postal_code --stop_model_call VA
```

There is also the corresponding PR in the testbed PR that this can be tested with: https://github.com/WashPost/elex-live-model-testbed/pull/27