### PR TITLE
now allows multiple alphas and returns dataframe

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -174,21 +174,23 @@ class ModelClient:
         raw_aggregate_list = base_aggregate + [aggregate]
         return sorted(list(set(raw_aggregate_list)), key=lambda x: AGGREGATE_ORDER.index(x))
 
-    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, base_to_add=0, alpha=0.99):
+    def get_national_summary_votes_estimates(self, nat_sum_data_dict=None, base_to_add=0, alphas=[0.99]):
         if self.model is None:
             raise ModelClientException(
                 "Must call the get_estimands() method before get_national_summary_votes_estimates()."
             )
 
-        nat_sum_estimates = self.model.get_national_summary_estimates(nat_sum_data_dict, base_to_add, alpha)
-        self.results_handler.add_national_summary_estimates(nat_sum_estimates)
+        nat_sum_estimates_dict = {}
+        for alpha in alphas:
+            nat_sum_estimates = self.model.get_national_summary_estimates(nat_sum_data_dict, base_to_add, alpha)
+            nat_sum_estimates_dict[alpha] = nat_sum_estimates
+        self.results_handler.add_national_summary_estimates(nat_sum_estimates_dict)
 
         if APP_ENV != "local" and self.save_results:
             self.results_handler.write_data(
                 self.election_id, self.office, self.geographic_unit_type, keys=["nat_sum_data"]
             )
-
-        return nat_sum_estimates
+        return self.results_handler.final_results['nat_sum_data']
 
     def get_estimates(
         self,

--- a/src/elexmodel/handlers/data/ModelResults.py
+++ b/src/elexmodel/handlers/data/ModelResults.py
@@ -106,10 +106,14 @@ class ModelResultsHandler:
                 lambda x, y: pd.merge(x, y, how="inner", on=merge_on), self.unit_data.values()
             )
 
-    def add_national_summary_estimates(self, national_summary_dict):
-        df = pd.DataFrame.from_dict(
-            national_summary_dict, orient="index", columns=["agg_pred", "agg_lower", "agg_upper"]
-        )
+    def add_national_summary_estimates(self, nat_sum_estimates_dict):
+        df = pd.DataFrame(index=["margin"])
+        for alpha, data in nat_sum_estimates_dict.items():
+            if 'agg_pred' not in df.columns:
+                df['agg_pred'] = [data['margin'][0]]
+            df[f'lower_{alpha}'] = [data['margin'][1]]
+            df[f'upper_{alpha}'] = [data['margin'][2]]
+
         df.index.name = "estimand"
         self.final_results["nat_sum_data"] = df.reset_index()
 


### PR DESCRIPTION
## Description
This PR allows us to pass multiple alphas to `get_national_summary_votes_estimates` and also changes the return object of the function to be a pandas dataframe where each alpha generates a separate lower and upper column.

This is necessary to avoid overwriting the agg model predictions in s3 when we run the model with 0.7 and 0.9 alphas.

## Jira Ticket

## Test Steps
Can be tested from the testbed. Will put the new testbed branch here.
