### PR TITLE
if we pass a lambda then no need for cv

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Some model types have specific model parameters that can be included.
 
 | Name                              | Type    | Acceptable values                | model           |
 |-----------------------------------|---------|----------------------------------|-----------------|
-| lambda                            | numeric | regularization constant          | all             |
+| lambda_                           | numeric | regularization constant          | all             |
 | turnout_factor_lower              | numeric | drop units with < turnout factor | all             |
 | turnout_factor_upper              | numeric | drop units with < turnout factor | all             |
 | robust                            | boolean | larger prediction intervals      | `nonparametric` |

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -811,9 +811,11 @@ class BootstrapElectionModel(BaseElectionModel):
         if self.lambda_ is None:
             optimal_lambda_y = self.cv_lambda(x_train, y_train, np.logspace(-3, 2, 20), weights=weights_train)
             optimal_lambda_z = self.cv_lambda(x_train, z_train, np.logspace(-3, 2, 20), weights=weights_train)
+            LOG.info(f"Optimal lambda for y: {optimal_lambda_y}, Optimal lambda for z: {optimal_lambda_z}")
         else:
             optimal_lambda_y = self.lambda_
             optimal_lambda_z = self.lambda_
+            LOG.info(f"Using user provided lambda: {self.lambda_}")
 
         # step 1) fit the initial model
         # we don't want to regularize the intercept or the coefficient for baseline_normalized_margin

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -58,7 +58,7 @@ class BootstrapElectionModel(BaseElectionModel):
             "agg_model_hard_threshold", True
         )  # use sigmoid or hard thresold when calculating agg model
         self.district_election = model_settings.get("district_election", False)
-        self.lambda_ = model_settings.get("lambda", None)  # regularization parameter for OLS
+        self.lambda_ = model_settings.get("lambda_", None)  # regularization parameter for OLS
 
         # upper and lower bounds for the quantile regression which define the strata distributions
         # these make sure that we can control the worst cases for the distributions in case we

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -58,6 +58,7 @@ class BootstrapElectionModel(BaseElectionModel):
             "agg_model_hard_threshold", True
         )  # use sigmoid or hard thresold when calculating agg model
         self.district_election = model_settings.get("district_election", False)
+        self.lambda_ = model_settings.get("lambda", None)  # regularization parameter for OLS
 
         # upper and lower bounds for the quantile regression which define the strata distributions
         # these make sure that we can control the worst cases for the distributions in case we
@@ -807,8 +808,12 @@ class BootstrapElectionModel(BaseElectionModel):
         )
 
         # we use k-fold cross validation to find the optimal lambda for our OLS regression
-        optimal_lambda_y = self.cv_lambda(x_train, y_train, np.logspace(-3, 2, 20), weights=weights_train)
-        optimal_lambda_z = self.cv_lambda(x_train, z_train, np.logspace(-3, 2, 20), weights=weights_train)
+        if self.lambda_ is None:
+            optimal_lambda_y = self.cv_lambda(x_train, y_train, np.logspace(-3, 2, 20), weights=weights_train)
+            optimal_lambda_z = self.cv_lambda(x_train, z_train, np.logspace(-3, 2, 20), weights=weights_train)
+        else:
+            optimal_lambda_y = self.lambda_
+            optimal_lambda_z = self.lambda_
 
         # step 1) fit the initial model
         # we don't want to regularize the intercept or the coefficient for baseline_normalized_margin

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -876,5 +876,9 @@ def test_get_national_summary_votes_estimates(model_client, va_governor_county_d
 
     current = model_client.get_national_summary_votes_estimates(None, 0, [0.99])
 
-    pd.testing.assert_frame_equal(current, model_client.results_handler.final_results["nat_sum_data"])
-    pd.testing.assert_frame_equal(expected_df, model_client.results_handler.final_results["nat_sum_data"])
+    pd.testing.assert_frame_equal(
+        current, model_client.results_handler.final_results["nat_sum_data"], check_dtype=False
+    )
+    pd.testing.assert_frame_equal(
+        expected_df, model_client.results_handler.final_results["nat_sum_data"], check_dtype=False
+    )


### PR DESCRIPTION
## Description
If we pass a lambda to the model, we don't need to do cross validation to find an optimal lambda. This is the real bottleneck our model has, and should help once we get late into election night.

## Jira Ticket

## Test Steps
You can test this in the testbed like so:
```
python run.py 2020-11-03_USA_G redo --office_id P --estimands="['margin']" --features "['baseline_normalized_margin', 'ethnicity_likely_african_american', 'percent_bachelor_or_higher']" --current_run_name "rerun_2020r" --agg_model_preds --start_timestamp 2020-11-03T19:54:29-05:00 --end_timestamp 2020-11-04T06:07:13-05:00 --redo_run_model_every_n 100 --model_parameters "{'lambda_': 1}"
```