### PR TITLE
Shrink the logging of non-modeled units down to up to three lines with units grouped by `postal_code`

### DIFF
--- a/src/elexmodel/client.py
+++ b/src/elexmodel/client.py
@@ -1,5 +1,4 @@
 import logging
-import pprint
 from collections import defaultdict
 
 import numpy as np
@@ -357,13 +356,14 @@ class ModelClient:
             There are {n_nonreporting_units} nonreporting units."""
         )
         if len(non_modeled_units) > 0:
-            non_modeled_units = (
-                non_modeled_units.groupby("unit_category")[["postal_code", "geographic_unit_fips"]]
-                .apply(lambda x: list(x.itertuples(index=False, name=None)))
-                .to_dict()
-            )
-            non_modeled_units_pprint = pprint.pformat(non_modeled_units)
-            LOG.info(f"non-modeled units:\n{non_modeled_units_pprint}")
+            for unit_category in sorted(set(non_modeled_units["unit_category"])):
+                category_non_modeled_units = (
+                    non_modeled_units[non_modeled_units["unit_category"] == unit_category]
+                    .groupby("postal_code")
+                    .agg({"geographic_unit_fips": list})
+                    .to_dict()["geographic_unit_fips"]
+                )
+                LOG.info(f"{unit_category}: {category_non_modeled_units}")
 
         if n_reporting_expected_units < minimum_reporting_units_max:
             raise ModelNotEnoughSubunitsException(


### PR DESCRIPTION
## Description

Hi!  The changes in this PR reduce the amount of logging of non-modeled units to a maximum of three lines (one per non-modeled unit category).  This should make our logs shorter and easier to navigate in the event of a lot of non-modeled units.  Thanks! 🎉 

## Jira Ticket

## Test Steps

`elexmodel 2020-11-03_USA_G --estimands=margin --features=baseline_normalized_margin --office_id=P --geographic_unit_type=county --pi_method bootstrap --national_summary` on `develop` and then on this branch to see the difference 👀 