### PR TITLE
Some small fixes to 2.2.0 release

### DIFF
--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -205,7 +205,9 @@ class CombinedDataHandler:
             fixed_effect for fixed_effect in fixed_effects if fixed_effect in reporting_units.columns
         ]
         featurizer = Featurizer(features=features_to_use, fixed_effects=fixed_effects_to_use)
-        x_data = featurizer.prepare_data(reporting_units)
+        x_data = featurizer.prepare_data(
+            reporting_units, center_features=False, scale_features=False, add_intercept=True
+        )
         y = reporting_units[response_variable]
         qr = QuantileRegressionSolver()
         qr.fit(x_data.values, y.values, weights=reporting_units["baseline_weights"].values, taus=[0.5])

--- a/src/elexmodel/handlers/data/CombinedData.py
+++ b/src/elexmodel/handlers/data/CombinedData.py
@@ -48,6 +48,7 @@ class CombinedDataHandler:
             data.update(data[result_cols].fillna(value=0))
             data.loc[indices_with_null_val, "percent_expected_vote"] = 0
 
+        self.n_minimum_for_outlier_detection_model = 20
         self.data = data
 
     def get_units(
@@ -245,7 +246,7 @@ class CombinedDataHandler:
 
         non_modeled_units_list = [units_blocklisted, units_with_zero_baseline, units_with_strange_turnout_factor]
 
-        if fit_turnout_outlier_model:
+        if fit_turnout_outlier_model and reporting_units.shape[0] > self.n_minimum_for_outlier_detection_model:
             units_with_strange_turnout_factor_modeled = self._fit_outlier_detection_model(
                 reporting_units, "turnout_factor", outlier_z_threshold
             )
@@ -253,7 +254,7 @@ class CombinedDataHandler:
             non_modeled_units_list.append(units_with_strange_turnout_factor_modeled)
 
         if "margin" in self.estimands:
-            if fit_margin_outlier_model:
+            if fit_margin_outlier_model and reporting_units.shape[0] > self.n_minimum_for_outlier_detection_model:
                 units_with_strange_margin_change_modeled = self._fit_outlier_detection_model(
                     reporting_units, "results_normalized_margin", outlier_z_threshold
                 )

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -145,7 +145,7 @@ class BootstrapElectionModel(BaseElectionModel):
                     lambda_=lambda_,
                     fit_intercept=True,
                     regularize_intercept=False,
-                    n_feat_ignore_reg=1,
+                    n_feat_ignore_reg=1 + len(self.states_for_separate_model),
                 )
                 y_hat_lambda = ols_lambda.predict(x_test)
                 # error is the weighted sum of squares of the residual between
@@ -911,7 +911,7 @@ class BootstrapElectionModel(BaseElectionModel):
             lambda_=optimal_lambda_y,
             fit_intercept=True,
             regularize_intercept=False,
-            n_feat_ignore_reg=1,
+            n_feat_ignore_reg=1 + len(self.states_for_separate_model),
         )
         ols_z = OLSRegressionSolver()
         ols_z.fit(
@@ -921,7 +921,7 @@ class BootstrapElectionModel(BaseElectionModel):
             lambda_=optimal_lambda_z,
             fit_intercept=True,
             regularize_intercept=False,
-            n_feat_ignore_reg=1,
+            n_feat_ignore_reg=1 + len(self.states_for_separate_model),
         )
 
         # step 2) calculate the fitted values
@@ -1015,7 +1015,7 @@ class BootstrapElectionModel(BaseElectionModel):
             normal_eqs=ols_y.normal_eqs,
             fit_intercept=True,
             regularize_intercept=False,
-            n_feat_ignore_reg=1,
+            n_feat_ignore_reg=1 + len(self.states_for_separate_model),
         )
         ols_z_B = OLSRegressionSolver()
         ols_z_B.fit(
@@ -1025,9 +1025,9 @@ class BootstrapElectionModel(BaseElectionModel):
             normal_eqs=ols_z.normal_eqs,
             fit_intercept=True,
             regularize_intercept=False,
-            n_feat_ignore_reg=1,
+            n_feat_ignore_reg=1 + len(self.states_for_separate_model),
         )
-
+        LOG.info("features: \n %s", self.featurizer.active_features)
         LOG.info("orig. ols coefficients, normalized margin: \n %s", ols_y.coefficients.flatten())
         LOG.info("boot. ols coefficients, normalized margin: \n %s", ols_y_B.coefficients.mean(axis=-1))
 

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -569,8 +569,6 @@ def test_separate_state_model():
     df_new = featurizer.prepare_data(df, center_features=False, scale_features=False, add_intercept=True)
     assert df_new.loc[df.postal_code != "CC", "intercept"].all() == 1
     assert df_new.loc[df.postal_code == "CC", "intercept"].all() == 0
-    assert df_new.loc[df.postal_code != "CC", "intercept_CC"].all() == 0
-    assert df_new.loc[df.postal_code == "CC", "intercept_CC"].all() == 1
 
     assert df_new.loc[df.postal_code != "CC", "a"].all() > 0
     assert df_new.loc[df.postal_code == "CC", "a"].all() == 0
@@ -595,12 +593,6 @@ def test_separate_state_model():
     assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "intercept"].all() == 1
     assert df_new.loc[df.postal_code == "CC", "intercept"].all() == 0
     assert df_new.loc[df.postal_code == "BB", "intercept"].all() == 0
-    assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "intercept_CC"].all() == 0
-    assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "intercept_BB"].all() == 0
-    assert df_new.loc[df.postal_code == "CC", "intercept_CC"].all() == 1
-    assert df_new.loc[df.postal_code == "BB", "intercept_BB"].all() == 1
-    assert df_new.loc[df.postal_code == "CC", "intercept_BB"].all() == 0
-    assert df_new.loc[df.postal_code == "BB", "intercept_CC"].all() == 0
 
     assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "a"].all() > 0
     assert df_new.loc[df.postal_code == "CC", "a"].all() == 0
@@ -620,5 +612,4 @@ def test_separate_state_model():
     assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "intercept"].all() == 1
     assert df_new.loc[df.postal_code == "CC", "intercept"].all() == 0
     assert df_new.loc[df.postal_code == "BB", "intercept"].all() == 0
-    assert "intercept_BB" not in df_new.columns
-    assert "intercept_CC" not in df_new.columns
+

--- a/tests/handlers/test_featurizer.py
+++ b/tests/handlers/test_featurizer.py
@@ -612,4 +612,3 @@ def test_separate_state_model():
     assert df_new.loc[(df.postal_code != "CC") & (df.postal_code != "BB"), "intercept"].all() == 1
     assert df_new.loc[df.postal_code == "CC", "intercept"].all() == 0
     assert df_new.loc[df.postal_code == "BB", "intercept"].all() == 0
-


### PR DESCRIPTION
## Description
* Adding a minimum number of units before we start running the outlier detection model.
* Removing fitting state specific intercept if passing state to `states_for_separate_model`
* Making sure that the `baseline_normalized_margin` comes right after the intercept when prepping the data to allow regularization.
* Adding an additional log for coefficients

## Jira Ticket

## Test Steps
