### PR TITLE
Remove min max electoral votes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ INSTALL_REQUIRES = (
     "boto3>=1.34",
     "python-dotenv>=1.0",
     "scipy>=1.14",
+    "s3transfer>=0.10.2",
+    "botocore>=1.35.18"
 )
 
 THIS_FILE_DIR = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ INSTALL_REQUIRES = (
     "python-dotenv>=1.0",
     "scipy>=1.14",
     "s3transfer>=0.10.2",
-    "botocore>=1.35.18"
+    "botocore>=1.35.18",
 )
 
 THIS_FILE_DIR = os.path.dirname(__file__)

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1806,20 +1806,6 @@ class BootstrapElectionModel(BaseElectionModel):
             potential_losses = pred_states - (~lower_states).astype(int)
             potential_gains = upper_states.astype(int) - pred_states
 
-        interval_upper = aggregate_dem_vals_pred + np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_gains)
-        interval_lower = aggregate_dem_vals_pred - np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_losses)
-
-        # B_1 and B_2 outcomes should respect called races
-        # because we create independent samples for B_1 and B_2 their difference can exaggerate the possible outcomes
-        # in the predicted lower and upper bounds.
-        # to undo this, we take the lower bound for B_1 and B_2 and the upper bound for B_1 and B_2 to max/min those
-        # with the predicted lower and upper bounds.
-        lower_bound = min(aggregate_dem_vals_B_1.sum(axis=0).min(), aggregate_dem_vals_B_2.sum(axis=0).min())
-        upper_bound = max(aggregate_dem_vals_B_1.sum(axis=0).max(), aggregate_dem_vals_B_2.sum(axis=0).max())
-
-        interval_lower = max(interval_lower, lower_bound)
-        interval_upper = min(interval_upper, upper_bound)
-
         if self.called_contests is not None:
             # if there is a call, there is no uncertainty in the outcome
             potential_losses[~np.isclose(self.called_contests.flatten(), -1)] = 0
@@ -1829,10 +1815,10 @@ class BootstrapElectionModel(BaseElectionModel):
             potential_losses[pred_states.astype(bool) & self.stop_model_call.flatten()] = 1
             potential_gains[~pred_states.astype(bool) & self.stop_model_call.flatten()] = 1
 
-            interval_lower = aggregate_dem_vals_pred - np.sum(
-                nat_sum_data_dict_sorted_vals.flatten() * potential_losses
-            )
-            interval_upper = aggregate_dem_vals_pred + np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_gains)
+        interval_lower = aggregate_dem_vals_pred - np.sum(
+            nat_sum_data_dict_sorted_vals.flatten() * potential_losses
+        )
+        interval_upper = aggregate_dem_vals_pred + np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_gains)
 
         agg_pred = round(aggregate_dem_vals_pred + base_to_add, 2)
         agg_lower = round(interval_lower + base_to_add, 2)

--- a/src/elexmodel/models/BootstrapElectionModel.py
+++ b/src/elexmodel/models/BootstrapElectionModel.py
@@ -1815,9 +1815,7 @@ class BootstrapElectionModel(BaseElectionModel):
             potential_losses[pred_states.astype(bool) & self.stop_model_call.flatten()] = 1
             potential_gains[~pred_states.astype(bool) & self.stop_model_call.flatten()] = 1
 
-        interval_lower = aggregate_dem_vals_pred - np.sum(
-            nat_sum_data_dict_sorted_vals.flatten() * potential_losses
-        )
+        interval_lower = aggregate_dem_vals_pred - np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_losses)
         interval_upper = aggregate_dem_vals_pred + np.sum(nat_sum_data_dict_sorted_vals.flatten() * potential_gains)
 
         agg_pred = round(aggregate_dem_vals_pred + base_to_add, 2)


### PR DESCRIPTION
## Description
We can now remove the min/max at the bottom of electoral votes estimation, since that is properly handled by potential gains and losses. Also adds explicit dependencies for extrapolation.

## Jira Ticket

## Test Steps
In the testbed, race calling as usual