### PR TITLE
downgraded s3transfer and botocore requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ INSTALL_REQUIRES = (
     "boto3>=1.34",
     "python-dotenv>=1.0",
     "scipy>=1.14",
-    "s3transfer>=0.10.2",
-    "botocore>=1.35.18",
+    "s3transfer>=0.9.0",
+    "botocore>=1.34.162",
 )
 
 THIS_FILE_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
## Description
Downgrading s3transfer and botocore requirements to make compatible with boto3 1.34.0, as the live team needs. Tested this in testbed and still works.

## Jira Ticket

## Test Steps
