### PR TITLE
Error handling

### DIFF
--- a/src/elexmodel/handlers/data/VersionedData.py
+++ b/src/elexmodel/handlers/data/VersionedData.py
@@ -122,7 +122,9 @@ class VersionedDataHandler:
 
             # check if perc_expected_vote_corr is monotone increasing (if not, give up and don't try to estimate a margin)
             if not np.all(np.diff(perc_expected_vote_corr) >= 0):
-                LOG.info(f"Non-monotonic percent_expected_vote in versioned data for {df.geographic_unit_fips.iloc[0]}")
+                LOG.info(
+                    f"Non-monotonic percent_expected_vote in versioned data for {df.geographic_unit_fips.iloc[0]}."
+                )
                 return pd.DataFrame(
                     {
                         "percent_expected_vote": np.arange(101),
@@ -150,7 +152,7 @@ class VersionedDataHandler:
             # batch_margins should be between -1 and 1 (otherwise, there was a data entry issue and we will not use this unit)
             if np.abs(batch_margin).max() > 1:
                 LOG.info(
-                    f"Implausible batch margin {np.abs(batch_margin).max()} in versioned data for {df.geographic_unit_fips.iloc[0]}"
+                    f"Implausible batch margin {np.abs(batch_margin).max()} in versioned data for {df.geographic_unit_fips.iloc[0]}."
                 )
                 return pd.DataFrame(
                     {

--- a/src/elexmodel/handlers/data/VersionedData.py
+++ b/src/elexmodel/handlers/data/VersionedData.py
@@ -122,11 +122,13 @@ class VersionedDataHandler:
 
             # check if perc_expected_vote_corr is monotone increasing (if not, give up and don't try to estimate a margin)
             if not np.all(np.diff(perc_expected_vote_corr) >= 0):
+                LOG.info(f"Non-monotonic percent_expected_vote in versioned data for {df.geographic_unit_fips.iloc[0]}")
                 return pd.DataFrame(
                     {
                         "percent_expected_vote": np.arange(101),
                         "nearest_observed_vote": np.nan * np.ones(101),
                         "est_margin": np.nan * np.ones(101),
+                        "est_correction": np.nan * np.ones(101),
                     }
                 )
 
@@ -147,11 +149,15 @@ class VersionedDataHandler:
 
             # batch_margins should be between -1 and 1 (otherwise, there was a data entry issue and we will not use this unit)
             if np.abs(batch_margin).max() > 1:
+                LOG.info(
+                    f"Implausible batch margin {np.abs(batch_margin).max()} in versioned data for {df.geographic_unit_fips.iloc[0]}"
+                )
                 return pd.DataFrame(
                     {
                         "percent_expected_vote": np.arange(101),
                         "nearest_observed_vote": np.nan * np.ones(101),
                         "est_margin": np.nan * np.ones(101),
+                        "est_correction": np.nan * np.ones(101),
                     }
                 )
 


### PR DESCRIPTION
## Description

The data frame returned by versioned results is missing the est_correction column when there is an issue with the data.
This can result in a model failure if *every* unit is returned without an est_correction column in a state. "compute_correction_statistics" in BootstrapElectionModel.py will fail because df.est_correction.notnull() doesn't just return all null's, the attribute doesn't exist.

## Jira Ticket

## Test Steps
