### PR TITLE
Route warnings to our logs

### DIFF
--- a/src/elexmodel/logger.py
+++ b/src/elexmodel/logger.py
@@ -18,7 +18,8 @@ LOGGING_CONFIG = {
             "handlers": ["default"],
             "level": "INFO",
             "propagate": True,
-        }
+        },
+        "py.warnings": {"handlers": ["default"], "level": "INFO", "propigate": True},
     },
 }
 
@@ -30,6 +31,7 @@ def initialize_logging(logging_config=None):
     if not logging_config:
         app_log_level = os.getenv("APP_LOG_LEVEL", "INFO")
         LOGGING_CONFIG["loggers"]["elexmodel"]["level"] = app_log_level
+        LOGGING_CONFIG["loggers"]["py.warnings"]["level"] = app_log_level
         logging_config = LOGGING_CONFIG
     logging.config.dictConfig(logging_config)
     logging.captureWarnings(True)


### PR DESCRIPTION
## Description

Hi!  The changes in this PR ensure that warnings appear in our logs.  With `logging.captureWarnings(True)`, Python creates a new logger called `py.warnings` and sends all of the warning messages there.  The change in this PR will make sure messages on the `py.warnings` logger also appear alongside our `elexmodel` logger messages 🎉 

## Jira Ticket

## Test Steps

Try this on `develop` and then on this branch:

```
elexmodel 2024-11-05_USA_G --estimands=margin --features=baseline_normalized_margin --office_id=S --geographic_unit_type=county --pi_method bootstrap --national_summary --model_parameters '{"extrapolation" : True, "versioned_start_date" : "2024-11-05T21:00:00-05:00", "versioned_end_date" : "2024-11-05T21:30:00-05:00"}'
```

😅 